### PR TITLE
feat: 회원가입 api 구현

### DIFF
--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/config/SecurityConfig.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/config/SecurityConfig.java
@@ -4,13 +4,16 @@ import com.budgetplanner.BudgetPlanner.auth.filter.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import static org.springframework.http.HttpMethod.*;
 
 @Configuration
 @EnableWebSecurity
@@ -27,6 +30,7 @@ public class SecurityConfig {
         return http
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(request -> request
+                        .requestMatchers(POST, "/api/signup").permitAll()
                         .anyRequest().authenticated()
                 )
 
@@ -37,5 +41,10 @@ public class SecurityConfig {
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
                 )
                 .build();
+    }
+
+    @Bean
+    public PasswordEncoder getPasswordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/controller/AuthController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.budgetplanner.BudgetPlanner.auth.controller;
+
+import com.budgetplanner.BudgetPlanner.auth.dto.UserSignupRequest;
+import com.budgetplanner.BudgetPlanner.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(@Valid @RequestBody UserSignupRequest request) {
+
+        authService.userSignup(request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(null);
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/dto/UserSignupRequest.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/dto/UserSignupRequest.java
@@ -1,0 +1,27 @@
+package com.budgetplanner.BudgetPlanner.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@NoArgsConstructor
+public class UserSignupRequest {
+
+    @NotBlank(message = "계정은 필수입력값입니다.")
+    private String account;
+
+    @NotBlank(message = "비밀번호는 필수입력값입니다.")
+    @Length(min = 10, message = "비밀번호는 10자 이상이여야합니다.")
+    @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z!@#$%^&*()-_=+]).+$", message = "비밀번호는 숫자, 문자, 특수문자 중 2가지 이상을 포함해야 합니다.")
+    private String password;
+
+    @Builder
+    public UserSignupRequest(String account, String password) {
+        this.account = account;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/service/AuthService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/service/AuthService.java
@@ -1,0 +1,37 @@
+package com.budgetplanner.BudgetPlanner.auth.service;
+
+import com.budgetplanner.BudgetPlanner.auth.dto.UserSignupRequest;
+import com.budgetplanner.BudgetPlanner.common.exception.CustomException;
+import com.budgetplanner.BudgetPlanner.common.exception.ErrorCode;
+import com.budgetplanner.BudgetPlanner.user.entity.User;
+import com.budgetplanner.BudgetPlanner.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+
+    @Transactional
+    public void userSignup(UserSignupRequest request) {
+
+        if (userRepository.findByAccount(request.getAccount()).isPresent()) {
+            throw new CustomException(ErrorCode.USER_ALREADY_EXIST);
+        }
+
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+        User user = User.builder()
+                .account(request.getAccount())
+                .password(encodedPassword)
+                .build();
+
+        userRepository.save(user);
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/user/entity/User.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/user/entity/User.java
@@ -1,0 +1,29 @@
+package com.budgetplanner.BudgetPlanner.user.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String account;
+
+    private String password;
+
+    @Builder
+    public User(String account, String password) {
+        this.account = account;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/user/repository/UserRepository.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.budgetplanner.BudgetPlanner.user.repository;
+
+import com.budgetplanner.BudgetPlanner.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByAccount(String account);
+
+}

--- a/src/test/java/com/budgetplanner/BudgetPlanner/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/budgetplanner/BudgetPlanner/auth/controller/AuthControllerTest.java
@@ -1,0 +1,89 @@
+package com.budgetplanner.BudgetPlanner.auth.controller;
+
+import com.budgetplanner.BudgetPlanner.auth.dto.UserSignupRequest;
+import com.budgetplanner.BudgetPlanner.auth.filter.JwtAuthenticationFilter;
+import com.budgetplanner.BudgetPlanner.auth.jwt.JwtUtils;
+import com.budgetplanner.BudgetPlanner.auth.service.AuthService;
+import com.budgetplanner.BudgetPlanner.common.exception.CustomException;
+import com.budgetplanner.BudgetPlanner.common.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AuthController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtils.class)
+        })
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthService authService;
+
+    @DisplayName("회원가입 성공")
+    @WithMockUser
+    @Test
+    void userSignup() throws Exception {
+        UserSignupRequest request = UserSignupRequest.builder()
+                .account("testAccount")
+                .password("test1234!@#$%")
+                .build();
+
+        String json = objectMapper.writeValueAsString(request);
+
+        mockMvc.perform(post("/api/signup").with(csrf())
+                        .content(json)
+                        .contentType(APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isCreated());
+
+        verify(authService).userSignup(any(UserSignupRequest.class));
+    }
+
+    @DisplayName("회원가입 실패 - 계정 중복")
+    @WithMockUser
+    @Test
+    void userSignupFail() throws Exception {
+
+        UserSignupRequest request = UserSignupRequest.builder()
+                .account("testAccount")
+                .password("test1234!@#$%")
+                .build();
+
+        doThrow(new CustomException(ErrorCode.USER_ALREADY_EXIST))
+                .when(authService).userSignup(any(UserSignupRequest.class));
+
+
+        String json = objectMapper.writeValueAsString(request);
+
+        mockMvc.perform(post("/api/signup").with(csrf())
+                        .content(json)
+                        .contentType(APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+
+        verify(authService).userSignup(any(UserSignupRequest.class));
+    }
+}

--- a/src/test/java/com/budgetplanner/BudgetPlanner/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/budgetplanner/BudgetPlanner/auth/service/AuthServiceTest.java
@@ -1,0 +1,74 @@
+package com.budgetplanner.BudgetPlanner.auth.service;
+
+import com.budgetplanner.BudgetPlanner.auth.dto.UserSignupRequest;
+import com.budgetplanner.BudgetPlanner.common.exception.CustomException;
+import com.budgetplanner.BudgetPlanner.user.entity.User;
+import com.budgetplanner.BudgetPlanner.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Spy
+    private PasswordEncoder passwordEncoder;
+
+    @DisplayName("회원가입 성공")
+    @Test
+    void signupSuccess() {
+
+        UserSignupRequest request = UserSignupRequest.builder()
+                .account("testAccount")
+                .password("test1234!@#$%")
+                .build();
+
+        String encodedPassword = "encodedPassword";
+
+        when(userRepository.findByAccount(request.getAccount())).thenReturn(Optional.empty());
+        when(passwordEncoder.encode(request.getPassword())).thenReturn(encodedPassword);
+
+        authService.userSignup(request);
+
+        verify(userRepository, times(1)).save(any());
+    }
+
+    @DisplayName("회원가입 실패 - 계정 중복")
+    @Test
+    void signupFailedWithDuplicateAccount() {
+        UserSignupRequest request = UserSignupRequest.builder()
+                .account("testAccount")
+                .password("test1234!@#$%")
+                .build();
+
+        User user = User.builder()
+                .account("testAccount")
+                .password("testpassword12!!!")
+                .build();
+
+
+        when(userRepository.findByAccount(request.getAccount())).thenReturn(Optional.of(user));
+
+        // 예외를 기대하는 테스트
+        assertThrows(CustomException.class, () -> authService.userSignup(request));
+
+        verify(userRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

회원가입 api를 구현하였습니다.
- 유저는 `계정`과 `비밀번호`로 회원가입을 진행합니다.
- 계정과 비밀번호는 빈 값일 수 없으며, 비밀번호는 최소 10글자 이상, 영어, 숫자, 특수문자 중 2개 이상을 사용해야 합니다.
- 계정은 `unique`합니다.
- 비밀번호는 암호화하여 저장합니다.
- 회원가입은 누구나 접근 가능하므로 security filter에서 허용시킵니다.

## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 테스트 추가, 테스트 리팩토링

## 📸 스크린샷

(선택 사항: 변경된 내용을 시각적으로 보여주기 위해 스크린샷을 첨부하세요.)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#5 

## 🙌 리뷰 및 피드백
