### PR TITLE
feat: 로그인 및 토큰 재발급 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'io.jsonwebtoken:jjwt:0.9.0'
+	implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/config/SecurityConfig.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(request -> request
                         .requestMatchers(POST, "/api/signup").permitAll()
                         .requestMatchers(POST, "/api/login").permitAll()
+                        .requestMatchers(POST, "/api/refresh").permitAll()
                         .anyRequest().authenticated()
                 )
 

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/config/SecurityConfig.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/config/SecurityConfig.java
@@ -25,18 +25,15 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
-        //WebSecurityCustomizer
-        //기본적으로 어느 URI를 허용하는지 결정함
         return http
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(request -> request
                         .requestMatchers(POST, "/api/signup").permitAll()
+                        .requestMatchers(POST, "/api/login").permitAll()
                         .anyRequest().authenticated()
                 )
 
-                //csrf(사이즈간 위조 요청) 설정 꺼놈 ->rest api는 stateless하기 떄문에 인증정보를 보관하지 않기 때문- token방식 사용
                 .csrf(CsrfConfigurer::disable)
-                //세션을 사용하지 않기때문에 STATELESS로 설정
                 .sessionManagement(sessionManagement ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
                 )

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/controller/AuthController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/controller/AuthController.java
@@ -1,15 +1,17 @@
 package com.budgetplanner.BudgetPlanner.auth.controller;
 
+import com.budgetplanner.BudgetPlanner.auth.dto.UserLoginRequest;
 import com.budgetplanner.BudgetPlanner.auth.dto.UserSignupRequest;
 import com.budgetplanner.BudgetPlanner.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,5 +26,34 @@ public class AuthController {
         authService.userSignup(request);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(null);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@Valid @RequestBody UserLoginRequest request) {
+
+        String[] tokens = authService.userLogin(request);
+
+        Map<String, String> response = new HashMap<>();
+
+        response.put("Bearer", tokens[0]);
+
+        ResponseCookie refreshToken = ResponseCookie.from("Bearer", tokens[1])
+                .httpOnly(true)
+                .path("/")
+                .maxAge(24 * 60 * 60)
+                .secure(true)
+                .build();
+
+        return ResponseEntity.ok().header("Set-Cookie", refreshToken.toString()).body(response);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refresh(@CookieValue("Bearer") String refreshToken) {
+        String newAccessToken = authService.issueRefreshToken(refreshToken);
+
+        Map<String, String> response = new HashMap<>();
+        response.put("Bearer", newAccessToken);
+
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/dto/UserLoginRequest.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/dto/UserLoginRequest.java
@@ -1,0 +1,23 @@
+package com.budgetplanner.BudgetPlanner.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserLoginRequest {
+
+    @NotBlank(message = "계정은 필수입니다.")
+    private String account;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+
+    @Builder
+    public UserLoginRequest(String account, String password) {
+        this.account = account;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/service/AuthService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/service/AuthService.java
@@ -1,6 +1,8 @@
 package com.budgetplanner.BudgetPlanner.auth.service;
 
+import com.budgetplanner.BudgetPlanner.auth.dto.UserLoginRequest;
 import com.budgetplanner.BudgetPlanner.auth.dto.UserSignupRequest;
+import com.budgetplanner.BudgetPlanner.auth.jwt.JwtUtils;
 import com.budgetplanner.BudgetPlanner.common.exception.CustomException;
 import com.budgetplanner.BudgetPlanner.common.exception.ErrorCode;
 import com.budgetplanner.BudgetPlanner.user.entity.User;
@@ -16,6 +18,7 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtUtils jwtUtils;
 
 
     @Transactional
@@ -33,5 +36,25 @@ public class AuthService {
                 .build();
 
         userRepository.save(user);
+    }
+
+    public String[] userLogin(UserLoginRequest request) {
+
+        userRepository.findByAccount(request.getAccount()).
+                filter(user -> {
+                    if (passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+                        return true;
+                    } else {
+                        throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
+                    }
+                })
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return jwtUtils.generateToken(request.getAccount());
+    }
+
+    public String issueRefreshToken(String refreshToken) {
+
+        return jwtUtils.verifyRefreshTokenAndReissue(refreshToken);
     }
 }

--- a/src/test/java/com/budgetplanner/BudgetPlanner/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/budgetplanner/BudgetPlanner/auth/controller/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.budgetplanner.BudgetPlanner.auth.controller;
 
+import com.budgetplanner.BudgetPlanner.auth.dto.UserLoginRequest;
 import com.budgetplanner.BudgetPlanner.auth.dto.UserSignupRequest;
 import com.budgetplanner.BudgetPlanner.auth.filter.JwtAuthenticationFilter;
 import com.budgetplanner.BudgetPlanner.auth.jwt.JwtUtils;
@@ -7,6 +8,7 @@ import com.budgetplanner.BudgetPlanner.auth.service.AuthService;
 import com.budgetplanner.BudgetPlanner.common.exception.CustomException;
 import com.budgetplanner.BudgetPlanner.common.exception.ErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -24,7 +27,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = AuthController.class,
         excludeFilters = {
@@ -78,6 +81,7 @@ class AuthControllerTest {
 
         String json = objectMapper.writeValueAsString(request);
 
+
         mockMvc.perform(post("/api/signup").with(csrf())
                         .content(json)
                         .contentType(APPLICATION_JSON))
@@ -86,4 +90,45 @@ class AuthControllerTest {
 
         verify(authService).userSignup(any(UserSignupRequest.class));
     }
+
+    @DisplayName("로그인 테스트")
+    @WithMockUser
+    @Test
+    void login() throws Exception {
+
+        UserLoginRequest request = UserLoginRequest.builder()
+                .account("testAccount")
+                .password("password123!!")
+                .build();
+
+        String[] returnData = new String[]{"access-token", "refresh-token"};
+
+        given(authService.userLogin(any(UserLoginRequest.class))).willReturn(returnData);
+
+        mockMvc.perform(post("/api/login").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().json("{\"Bearer\":\"access-token\"}")) //응답 액세스토큰
+                .andExpect(cookie().value("Bearer", "refresh-token")); //쿠키 리프레시토큰
+    }
+
+    @DisplayName("새로운 액세스 토큰 발급")
+    @WithMockUser
+    @Test
+    void issueRefreshToken() throws Exception{
+
+        String refreshToken = "refresh-token";
+        String newAccessToken = "new-access-token";
+
+        given(authService.issueRefreshToken(refreshToken)).willReturn(newAccessToken);
+
+        mockMvc.perform(post("/api/refresh").with(csrf())
+                        .cookie(new Cookie("Bearer", refreshToken)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().json("{\"Bearer\":\"new-access-token\"}"));
+    }
+
 }

--- a/src/test/java/com/budgetplanner/BudgetPlanner/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/budgetplanner/BudgetPlanner/auth/service/AuthServiceTest.java
@@ -1,6 +1,8 @@
 package com.budgetplanner.BudgetPlanner.auth.service;
 
+import com.budgetplanner.BudgetPlanner.auth.dto.UserLoginRequest;
 import com.budgetplanner.BudgetPlanner.auth.dto.UserSignupRequest;
+import com.budgetplanner.BudgetPlanner.auth.jwt.JwtUtils;
 import com.budgetplanner.BudgetPlanner.common.exception.CustomException;
 import com.budgetplanner.BudgetPlanner.user.entity.User;
 import com.budgetplanner.BudgetPlanner.user.repository.UserRepository;
@@ -27,6 +29,9 @@ class AuthServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private JwtUtils jwtUtils;
 
     @Spy
     private PasswordEncoder passwordEncoder;
@@ -70,5 +75,94 @@ class AuthServiceTest {
         assertThrows(CustomException.class, () -> authService.userSignup(request));
 
         verify(userRepository, never()).save(any());
+    }
+
+    @DisplayName("로그인 성공")
+    @Test
+    void login_Success() {
+        // Arrange
+        String account = "testAccount";
+        String password = "password123";
+        String encodedPassword = "encodedPassword123";
+        String[] tokens = new String[]{"access-token", "refresh-token"};
+
+        UserLoginRequest request = UserLoginRequest.builder()
+                .account(account)
+                .password(password)
+                .build();
+
+        User user = User.builder()
+                .account(account)
+                .password(encodedPassword)
+                .build();
+
+        //given
+        when(userRepository.findByAccount(account)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(password, encodedPassword)).thenReturn(true);
+        when(jwtUtils.generateToken(account)).thenReturn(tokens);
+
+        //when
+        String[] result = authService.userLogin(request);
+
+        //then
+        assertEquals(tokens[0], result[0]);
+        assertEquals(tokens[1], result[1]);
+    }
+
+    @DisplayName("로그인 시 유저 못찾음")
+    @Test
+    void login_UserNotFound() {
+        String account = "testAccount";
+        String password = "password123";
+
+        UserLoginRequest request = UserLoginRequest.builder()
+                .account(account)
+                .password(password)
+                .build();
+
+        //given
+        when(userRepository.findByAccount(account)).thenReturn(Optional.empty());
+
+        //then
+        assertThrows(CustomException.class, () -> authService.userLogin(request));
+    }
+
+    @DisplayName("로그인시 패스워드 일치하지 않음")
+    @Test
+    void login_PasswordMismatch() {
+        String account = "testAccount";
+        String password = "password123";
+        String encodedPassword = "encodedPassword123";
+
+        UserLoginRequest request = UserLoginRequest.builder()
+                .account(account)
+                .password(password)
+                .build();
+
+        User user = User.builder()
+                .account(account)
+                .password(encodedPassword)
+                .build();
+
+        //given
+        when(userRepository.findByAccount(account)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(password, encodedPassword)).thenReturn(false);
+
+        //then
+        assertThrows(CustomException.class, () -> authService.userLogin(request));
+    }
+
+    @DisplayName("토큰 재발급")
+    @Test
+    void issueNewAccessToken() {
+
+        String refreshToken = "refresh-token";
+        String newAccessToken = "new-access-token";
+
+        when(jwtUtils.verifyRefreshTokenAndReissue(refreshToken)).thenReturn(newAccessToken);
+
+        String result = authService.issueRefreshToken(refreshToken);
+
+        assertEquals(newAccessToken, result);
     }
 }


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

- 회원가입한 유저는 계정과 비밀번호를 통해 로그인합니다.
- 로그인 한 유저에게 `응답으로 access토큰`, `쿠키로 refresh토큰`을 발급합니다.
- 토큰 재발급 api는 `refresh토큰으로 검증`하여` access토큰을 재발급`해 줍니다.


## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 테스트 추가, 테스트 리팩토링

## 📸 스크린샷


## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#7 

## 🙌 리뷰 및 피드백
