### PR TITLE
feat: 예산 설정 및 설계

### DIFF
--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/entity/Budget.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/entity/Budget.java
@@ -1,0 +1,39 @@
+package com.budgetplanner.BudgetPlanner.budget.entity;
+
+import com.budgetplanner.BudgetPlanner.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.YearMonth;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Budget {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    //예산
+    private Long budget;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    @Column(name = "yyyy_mm")
+    private YearMonth yearMonth;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    public Budget(Long budget, Category category, YearMonth yearMonth, User user) {
+        this.budget = budget;
+        this.category = category;
+        this.yearMonth = yearMonth;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/entity/Category.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/entity/Category.java
@@ -1,0 +1,21 @@
+package com.budgetplanner.BudgetPlanner.budget.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Category{
+
+    FOOD_EXPENSES("식비"),
+    TRANSPORTATION_EXPENSES("교통비"),
+    HOUSING_EXPENSES("주거비"),
+    SAVING_EXPENSES("저축비"),
+    ETC_EXPENSES("기타비"),
+    ;
+
+    private final String categoryName;
+
+    Category(String categoryName) {
+        this.categoryName = categoryName;
+    }
+
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/user/entity/User.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/user/entity/User.java
@@ -1,9 +1,6 @@
 package com.budgetplanner.BudgetPlanner.user.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user")
 public class User {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

- 예산에 관련한 api를 작성하기 위해 도메인 설계를 진행합니다.
- 예산은 `설정할 예산`과 `년월`, `카테고리`, `회원을` 요소로 저장됩니다.
- 카테고리는 기본적으로 `식비, 교통비, 주거비, 저축비, 기타비` 로 구성됩니다.
- 유저 테이블에 @Table(name="user")를 지정함으로 mysql 쿼리 에러를 방지합니다.

## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 버그 수정

## 📸 스크린샷


## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.

## 📎 관련 이슈

#9 

## 🙌 리뷰 및 피드백
