### PR TITLE
feat: 카테고리 목록 조회 api 구현

### DIFF
--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/controller/BudgetController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/controller/BudgetController.java
@@ -1,0 +1,28 @@
+package com.budgetplanner.BudgetPlanner.budget.controller;
+
+
+import com.budgetplanner.BudgetPlanner.budget.dto.CategoriesResponse;
+import com.budgetplanner.BudgetPlanner.budget.service.BudgetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/budgets")
+public class BudgetController {
+
+    private final BudgetService budgetService;
+
+    @GetMapping("/categories")
+    public ResponseEntity<?> getCategories() {
+
+        List<CategoriesResponse> categories = budgetService.getCategories();
+
+        return ResponseEntity.status(HttpStatus.OK).body(categories);
+    }
+
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/dto/CategoriesResponse.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/dto/CategoriesResponse.java
@@ -1,0 +1,15 @@
+package com.budgetplanner.BudgetPlanner.budget.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CategoriesResponse {
+
+    private String categoryCode;
+    private String categoryName;
+
+    public CategoriesResponse(String categoryCode, String categoryName) {
+        this.categoryCode = categoryCode;
+        this.categoryName = categoryName;
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/service/BudgetService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/service/BudgetService.java
@@ -1,0 +1,22 @@
+package com.budgetplanner.BudgetPlanner.budget.service;
+
+import com.budgetplanner.BudgetPlanner.budget.dto.CategoriesResponse;
+import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BudgetService {
+
+    public List<CategoriesResponse> getCategories() {
+
+        return Arrays.stream(Category.values())
+                .map(category -> new CategoriesResponse(category.name(), category.getCategoryName()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/com/budgetplanner/BudgetPlanner/budget/controller/BudgetControllerTest.java
+++ b/src/test/java/com/budgetplanner/BudgetPlanner/budget/controller/BudgetControllerTest.java
@@ -1,0 +1,66 @@
+package com.budgetplanner.BudgetPlanner.budget.controller;
+
+import com.budgetplanner.BudgetPlanner.auth.filter.JwtAuthenticationFilter;
+import com.budgetplanner.BudgetPlanner.auth.jwt.JwtUtils;
+import com.budgetplanner.BudgetPlanner.budget.dto.CategoriesResponse;
+import com.budgetplanner.BudgetPlanner.budget.service.BudgetService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = BudgetController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtils.class)
+        })
+class BudgetControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private BudgetService budgetService;
+
+    @DisplayName("카테고리 목록 조회")
+    @WithMockUser
+    @Test
+    void showCategories() throws Exception {
+        List<CategoriesResponse> expectedCategories = Arrays.asList(
+                new CategoriesResponse("FOOD_EXPENSES", "식비"),
+                new CategoriesResponse("TRANSPORTATION_EXPENSES", "교통비"),
+                new CategoriesResponse("HOUSING_EXPENSES", "주거비"),
+                new CategoriesResponse("SAVING_EXPENSES", "저축비"),
+                new CategoriesResponse("ETC_EXPENSES", "기타비")
+        );
+
+        when(budgetService.getCategories()).thenReturn(expectedCategories);
+
+        mockMvc.perform(get("/api/budgets/categories").with(csrf())
+                        .contentType(APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(budgetService).getCategories();
+    }
+}

--- a/src/test/java/com/budgetplanner/BudgetPlanner/budget/service/BudgetServiceTest.java
+++ b/src/test/java/com/budgetplanner/BudgetPlanner/budget/service/BudgetServiceTest.java
@@ -1,0 +1,39 @@
+package com.budgetplanner.BudgetPlanner.budget.service;
+
+import com.budgetplanner.BudgetPlanner.auth.jwt.JwtUtils;
+import com.budgetplanner.BudgetPlanner.budget.dto.CategoriesResponse;
+import com.budgetplanner.BudgetPlanner.budget.repository.BudgetRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class BudgetServiceTest {
+
+    @InjectMocks
+    private BudgetService budgetService;
+
+    @Mock
+    private BudgetRepository budgetRepository;
+
+
+    @DisplayName("카테고리 목록 조회")
+    @Test
+    void showCategories() {
+
+        List<CategoriesResponse> categories = budgetService.getCategories();
+
+        assertEquals(5, categories.size());
+        assertEquals(categories.get(0).getCategoryCode(), "FOOD_EXPENSES");
+        assertEquals(categories.get(1).getCategoryName(), "교통비");
+
+    }
+
+}


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

예산 설정에 사용할 카테고리 목록을 조회하는 api를 구현합니다.

## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 테스트 추가, 테스트 리팩토링

## 📸 스크린샷


## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#10 

## 🙌 리뷰 및 피드백
