### PR TITLE
feat: 예산 설정 및 추천 api 구현

### DIFF
--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/controller/BudgetController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/controller/BudgetController.java
@@ -1,11 +1,13 @@
 package com.budgetplanner.BudgetPlanner.budget.controller;
 
-
+import com.budgetplanner.BudgetPlanner.budget.dto.BudgetSettingsRequest;
 import com.budgetplanner.BudgetPlanner.budget.dto.CategoriesResponse;
 import com.budgetplanner.BudgetPlanner.budget.service.BudgetService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -23,6 +25,15 @@ public class BudgetController {
         List<CategoriesResponse> categories = budgetService.getCategories();
 
         return ResponseEntity.status(HttpStatus.OK).body(categories);
+    }
+
+    @PostMapping
+    public ResponseEntity<?> budgetSettings(@Valid @RequestBody BudgetSettingsRequest request,
+                                            Authentication authentication) {
+
+        budgetService.setting(request, authentication);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(null);
     }
 
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/controller/BudgetController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/controller/BudgetController.java
@@ -1,5 +1,7 @@
 package com.budgetplanner.BudgetPlanner.budget.controller;
 
+import com.budgetplanner.BudgetPlanner.budget.dto.BudgetRecommendRequest;
+import com.budgetplanner.BudgetPlanner.budget.dto.BudgetRecommendResponse;
 import com.budgetplanner.BudgetPlanner.budget.dto.BudgetSettingsRequest;
 import com.budgetplanner.BudgetPlanner.budget.dto.CategoriesResponse;
 import com.budgetplanner.BudgetPlanner.budget.service.BudgetService;
@@ -36,4 +38,11 @@ public class BudgetController {
         return ResponseEntity.status(HttpStatus.CREATED).body(null);
     }
 
+    @GetMapping
+    public ResponseEntity<?> recommendBudgets(@RequestBody BudgetRecommendRequest request) {
+
+        List<BudgetRecommendResponse> list = budgetService.recommend(request);
+
+        return ResponseEntity.status(HttpStatus.OK).body(list);
+    }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/dto/BudgetRecommendRequest.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/dto/BudgetRecommendRequest.java
@@ -1,0 +1,9 @@
+package com.budgetplanner.BudgetPlanner.budget.dto;
+
+import lombok.Getter;
+
+@Getter
+public class BudgetRecommendRequest {
+
+    private Long budget;
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/dto/BudgetRecommendResponse.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/dto/BudgetRecommendResponse.java
@@ -1,0 +1,16 @@
+package com.budgetplanner.BudgetPlanner.budget.dto;
+
+import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import lombok.Getter;
+
+@Getter
+public class BudgetRecommendResponse {
+
+    private Category category;
+    private Long budget;
+
+    public BudgetRecommendResponse(Category category, Long budget) {
+        this.category = category;
+        this.budget = budget;
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/dto/BudgetSettingsRequest.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/dto/BudgetSettingsRequest.java
@@ -1,0 +1,24 @@
+package com.budgetplanner.BudgetPlanner.budget.dto;
+
+import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.YearMonth;
+import java.util.List;
+
+@Getter
+public class BudgetSettingsRequest {
+
+    @NotNull(message = "카테고리와 예산은 필수입니다.")
+    private List<CreateCategoryAndBudget> categoryAndBudget;
+
+    @NotNull(message = "년, 월은 필수입니다.")
+    private YearMonth yearMonth;
+
+    @Getter
+    public static class CreateCategoryAndBudget {
+        private Category category;
+        private Long budget;
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/dto/BudgetSettingsRequest.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/dto/BudgetSettingsRequest.java
@@ -2,12 +2,15 @@ package com.budgetplanner.BudgetPlanner.budget.dto;
 
 import com.budgetplanner.BudgetPlanner.budget.entity.Category;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.YearMonth;
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
 public class BudgetSettingsRequest {
 
     @NotNull(message = "카테고리와 예산은 필수입니다.")
@@ -17,8 +20,20 @@ public class BudgetSettingsRequest {
     private YearMonth yearMonth;
 
     @Getter
+    @NoArgsConstructor
     public static class CreateCategoryAndBudget {
         private Category category;
         private Long budget;
+
+        public CreateCategoryAndBudget(Category category, Long budget) {
+            this.category = category;
+            this.budget = budget;
+        }
+    }
+
+    @Builder
+    public BudgetSettingsRequest(List<CreateCategoryAndBudget> categoryAndBudget, YearMonth yearMonth) {
+        this.categoryAndBudget = categoryAndBudget;
+        this.yearMonth = yearMonth;
     }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/repository/BudgetRepository.java
@@ -7,4 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface BudgetRepository extends JpaRepository<Budget, Long> {
+
+    @Query("SELECT b.category, SUM(b.budget) FROM Budget b GROUP BY b.category")
+    List<Object[]> findCategoryAndBudget();
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/repository/BudgetRepository.java
@@ -1,0 +1,10 @@
+package com.budgetplanner.BudgetPlanner.budget.repository;
+
+import com.budgetplanner.BudgetPlanner.budget.entity.Budget;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface BudgetRepository extends JpaRepository<Budget, Long> {
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/service/BudgetService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/service/BudgetService.java
@@ -1,17 +1,30 @@
 package com.budgetplanner.BudgetPlanner.budget.service;
 
+import com.budgetplanner.BudgetPlanner.budget.dto.BudgetSettingsRequest;
 import com.budgetplanner.BudgetPlanner.budget.dto.CategoriesResponse;
+import com.budgetplanner.BudgetPlanner.budget.entity.Budget;
 import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import com.budgetplanner.BudgetPlanner.budget.repository.BudgetRepository;
+import com.budgetplanner.BudgetPlanner.common.exception.CustomException;
+import com.budgetplanner.BudgetPlanner.common.exception.ErrorCode;
+import com.budgetplanner.BudgetPlanner.user.entity.User;
+import com.budgetplanner.BudgetPlanner.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+
 @Service
 @RequiredArgsConstructor
 public class BudgetService {
+
+    private final BudgetRepository budgetRepository;
+    private final UserRepository userRepository;
 
     public List<CategoriesResponse> getCategories() {
 
@@ -19,4 +32,34 @@ public class BudgetService {
                 .map(category -> new CategoriesResponse(category.name(), category.getCategoryName()))
                 .collect(Collectors.toList());
     }
+
+    @Transactional
+    public void setting(BudgetSettingsRequest request, Authentication authentication) {
+
+        User user = userRepository.findByAccount(authentication.getName())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        checkTheNumberOfEnteredCategories(request);
+
+        saveBudgets(request, user);
+    }
+
+    //모든 카테고리가 입력되야 하므로 갯수를 검사한다.
+    private void checkTheNumberOfEnteredCategories(BudgetSettingsRequest request) {
+        if (request.getCategoryAndBudget().size() != Category.values().length) {
+            throw new CustomException(ErrorCode.CATEGORY_MISSING);
+        }
+    }
+
+    private void saveBudgets(BudgetSettingsRequest request, User user) {
+        request.getCategoryAndBudget().stream()
+                .map(createCategoryAndBudget -> Budget.builder()
+                        .budget(createCategoryAndBudget.getBudget())
+                        .category(createCategoryAndBudget.getCategory())
+                        .yearMonth(request.getYearMonth())
+                        .user(user)
+                        .build())
+                .forEach(budgetRepository::save);
+    }
+
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/common/exception/ErrorCode.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/common/exception/ErrorCode.java
@@ -16,6 +16,9 @@ public enum ErrorCode {
     //auth
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "잘못된 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "만료된 토큰입니다."),
+
+    //budget
+    CATEGORY_MISSING(HttpStatus.BAD_REQUEST, "B001", "카테고리에 대한 예산을 모두 입력해주세요."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

- 예산 설정 및 예산 추천 api를 구현하였습니다.
- 예산 설정은 각 카테고리마다 예산을 입력하여 저장하고, `유저`와 `예산`을 `일대다 관계`로 설정하였습니다.
- 예산 추천은 예산 설정에 대한 추천을 받고자 하면, 사람들의 평균적인 비율을 고려하여 입력한 예산에 대해 자동으로 추천해줍니다.

## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 테스트 추가, 테스트 리팩토링

## 📸 스크린샷

(선택 사항: 변경된 내용을 시각적으로 보여주기 위해 스크린샷을 첨부하세요.)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#13 

## 🙌 리뷰 및 피드백
