### PR TITLE
feat: 지출 CRUD 구현

### DIFF
--- a/src/main/java/com/budgetplanner/BudgetPlanner/common/exception/ErrorCode.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/common/exception/ErrorCode.java
@@ -19,6 +19,10 @@ public enum ErrorCode {
 
     //budget
     CATEGORY_MISSING(HttpStatus.BAD_REQUEST, "B001", "카테고리에 대한 예산을 모두 입력해주세요."),
+
+    //expense
+    EXPENSE_NOT_FOUND(HttpStatus.NOT_FOUND, "E001", "해당 지출을 찾을 수 없습니다."),
+    EXPENSE_USER_MISMATCH(HttpStatus.BAD_REQUEST, "E002", "기록한 유저와 찾을 유저가 일치하지 않습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
@@ -1,9 +1,6 @@
 package com.budgetplanner.BudgetPlanner.expense.controller;
 
-import com.budgetplanner.BudgetPlanner.expense.dto.CreateExpenseRequest;
-import com.budgetplanner.BudgetPlanner.expense.dto.GetExpenseResponse;
-import com.budgetplanner.BudgetPlanner.expense.dto.GetExpensesResponse;
-import com.budgetplanner.BudgetPlanner.expense.dto.UpdateExpenseRequest;
+import com.budgetplanner.BudgetPlanner.expense.dto.*;
 import com.budgetplanner.BudgetPlanner.expense.service.ExpenseService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -11,8 +8,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,9 +34,10 @@ public class ExpenseController {
     }
 
     @GetMapping
-    public ResponseEntity<?> getExpenses(Authentication authentication) {
+    public ResponseEntity<?> getExpenses(Authentication authentication,
+                                         ParamsRequest request) {
 
-        List<GetExpensesResponse> response = expenseService.getExpenses(authentication);
+        ResultExpensesResponse response = expenseService.getExpenses(authentication, request);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
@@ -1,0 +1,30 @@
+package com.budgetplanner.BudgetPlanner.expense.controller;
+
+import com.budgetplanner.BudgetPlanner.expense.dto.CreateExpenseRequest;
+import com.budgetplanner.BudgetPlanner.expense.service.ExpenseService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/expense")
+public class ExpenseController {
+
+    private final ExpenseService expenseService;
+
+    @PostMapping
+    public ResponseEntity<?> createExpense(@Valid @RequestBody CreateExpenseRequest request,
+                                           Authentication authentication) {
+
+        expenseService.create(request, authentication);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(null);
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
@@ -2,6 +2,7 @@ package com.budgetplanner.BudgetPlanner.expense.controller;
 
 import com.budgetplanner.BudgetPlanner.expense.dto.CreateExpenseRequest;
 import com.budgetplanner.BudgetPlanner.expense.dto.GetExpenseResponse;
+import com.budgetplanner.BudgetPlanner.expense.dto.GetExpensesResponse;
 import com.budgetplanner.BudgetPlanner.expense.service.ExpenseService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,6 +33,14 @@ public class ExpenseController {
     public ResponseEntity<?> getExpense(@PathVariable Long id, Authentication authentication) {
 
         GetExpenseResponse response = expenseService.getExpense(id, authentication);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getExpenses(Authentication authentication) {
+
+        List<GetExpensesResponse> response = expenseService.getExpenses(authentication);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
@@ -1,16 +1,14 @@
 package com.budgetplanner.BudgetPlanner.expense.controller;
 
 import com.budgetplanner.BudgetPlanner.expense.dto.CreateExpenseRequest;
+import com.budgetplanner.BudgetPlanner.expense.dto.GetExpenseResponse;
 import com.budgetplanner.BudgetPlanner.expense.service.ExpenseService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,4 +25,13 @@ public class ExpenseController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(null);
     }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getExpense(@PathVariable Long id, Authentication authentication) {
+
+        GetExpenseResponse response = expenseService.getExpense(id, authentication);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
@@ -24,7 +24,6 @@ public class ExpenseController {
     @PostMapping
     public ResponseEntity<?> createExpense(@Valid @RequestBody CreateExpenseRequest request,
                                            Authentication authentication) {
-        //todo 저장할때 지금 시간 말고 사용자가 지정한 시간으로 변경할 것
 
         expenseService.create(request, authentication);
 

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
@@ -57,4 +57,12 @@ public class ExpenseController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
     }
 
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteExpense(@PathVariable Long id,
+                                           Authentication authentication) {
+        expenseService.delete(id, authentication);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
+    }
+
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
@@ -64,4 +64,12 @@ public class ExpenseController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
     }
 
+    @PatchMapping("/{id}/exclude")
+    public ResponseEntity<?> excludeExpense(@PathVariable Long id,
+                                            Authentication authentication) {
+        expenseService.exclude(id, authentication);
+
+        return ResponseEntity.status(HttpStatus.OK).body(null);
+    }
+
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
@@ -3,6 +3,7 @@ package com.budgetplanner.BudgetPlanner.expense.controller;
 import com.budgetplanner.BudgetPlanner.expense.dto.CreateExpenseRequest;
 import com.budgetplanner.BudgetPlanner.expense.dto.GetExpenseResponse;
 import com.budgetplanner.BudgetPlanner.expense.dto.GetExpensesResponse;
+import com.budgetplanner.BudgetPlanner.expense.dto.UpdateExpenseRequest;
 import com.budgetplanner.BudgetPlanner.expense.service.ExpenseService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class ExpenseController {
     @PostMapping
     public ResponseEntity<?> createExpense(@Valid @RequestBody CreateExpenseRequest request,
                                            Authentication authentication) {
+        //todo 저장할때 지금 시간 말고 사용자가 지정한 시간으로 변경할 것
 
         expenseService.create(request, authentication);
 
@@ -43,6 +45,16 @@ public class ExpenseController {
         List<GetExpensesResponse> response = expenseService.getExpenses(authentication);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<?> updateExpense(@PathVariable Long id,
+                                           Authentication authentication,
+                                           @RequestBody UpdateExpenseRequest request) {
+
+        expenseService.update(id, authentication, request);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
     }
 
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/CreateExpenseRequest.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/CreateExpenseRequest.java
@@ -1,0 +1,17 @@
+package com.budgetplanner.BudgetPlanner.expense.dto;
+
+import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class CreateExpenseRequest {
+
+    @NotNull(message = "지출 비용은 필수입니다.")
+    private Long expenses;
+
+    @NotNull(message = "카테고리 지정은 필수입니다.")
+    private Category category;
+
+    private String memo;
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/CreateExpenseRequest.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/CreateExpenseRequest.java
@@ -1,8 +1,11 @@
 package com.budgetplanner.BudgetPlanner.expense.dto;
 
 import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter
 public class CreateExpenseRequest {
@@ -14,4 +17,8 @@ public class CreateExpenseRequest {
     private Category category;
 
     private String memo;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    @NotNull(message = "지출 시간은 필수입니다.")
+    private LocalDateTime spendingTime;
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/GetExpenseResponse.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/GetExpenseResponse.java
@@ -1,0 +1,31 @@
+package com.budgetplanner.BudgetPlanner.expense.dto;
+
+import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class GetExpenseResponse {
+
+    private Long id;
+    private Long userId;
+    private Category category;
+    private Long expenses;
+    private LocalDateTime spendingTime;
+    private String memo;
+    private boolean excludeTotalExpenses;
+
+    @Builder
+    public GetExpenseResponse(Long id, Long userId, Category category, Long expenses
+            , LocalDateTime spendingTime, String memo, boolean excludeTotalExpenses) {
+        this.id = id;
+        this.userId = userId;
+        this.category = category;
+        this.expenses = expenses;
+        this.spendingTime = spendingTime;
+        this.memo = memo;
+        this.excludeTotalExpenses = excludeTotalExpenses;
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/GetExpensesResponse.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/GetExpensesResponse.java
@@ -1,0 +1,30 @@
+package com.budgetplanner.BudgetPlanner.expense.dto;
+
+import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import com.budgetplanner.BudgetPlanner.expense.entity.Expense;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class GetExpensesResponse {
+
+    private Long id;
+    private Category category;
+    private Long expenses;
+    private LocalDateTime spendingTime;
+    private String memo;
+    private boolean excludeTotalExpenses;
+
+    public GetExpensesResponse(Expense expense) {
+        this.id = expense.getId();
+        this.category = expense.getCategory();
+        this.expenses = expense.getExpenses();
+        this.spendingTime = expense.getSpendingTime();
+        this.memo = expense.getMemo();
+        this.excludeTotalExpenses = expense.isExcludeTotalExpenses();
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/ParamsRequest.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/ParamsRequest.java
@@ -1,0 +1,14 @@
+package com.budgetplanner.BudgetPlanner.expense.dto;
+
+import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+
+public record ParamsRequest(@RequestParam(name = "start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+                            @RequestParam(name = "end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)LocalDate end,
+                            @RequestParam(name = "category", required = false) Category category,
+                            @RequestParam(name = "min", required = false) Long min,
+                            @RequestParam(name = "max", required = false) Long max) {
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/ResultExpensesResponse.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/ResultExpensesResponse.java
@@ -1,0 +1,23 @@
+package com.budgetplanner.BudgetPlanner.expense.dto;
+
+import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class ResultExpensesResponse {
+
+    private Long totalExpenses;
+    private Map<Category, Long> categoryExpenses;
+    private List<GetExpensesResponse> expenses;
+
+    @Builder
+    public ResultExpensesResponse(Long totalExpenses, Map<Category, Long> categoryExpenses, List<GetExpensesResponse> expenses) {
+        this.totalExpenses = totalExpenses;
+        this.categoryExpenses = categoryExpenses;
+        this.expenses = expenses;
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/UpdateExpenseRequest.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/UpdateExpenseRequest.java
@@ -1,0 +1,19 @@
+package com.budgetplanner.BudgetPlanner.expense.dto;
+
+import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class UpdateExpenseRequest {
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    private LocalDateTime spendingTime;
+
+    private Long expenses;
+    private Category category;
+    private String memo;
+    private boolean excludeTotalExpenses;
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/UpdateExpenseRequest.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/UpdateExpenseRequest.java
@@ -15,5 +15,4 @@ public class UpdateExpenseRequest {
     private Long expenses;
     private Category category;
     private String memo;
-    private boolean excludeTotalExpenses;
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/entity/Expense.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/entity/Expense.java
@@ -44,11 +44,10 @@ public class Expense {
     }
 
     public void update(LocalDateTime spendingTime, Long expenses
-            , Category category, String memo, boolean excludeTotalExpenses) {
+            , Category category, String memo) {
         this.spendingTime = spendingTime != null ? spendingTime : this.spendingTime;
         this.expenses = expenses != null ? expenses : this.expenses;
         this.category = category != null ? category : this.category;
         this.memo = memo != null ? memo : this.memo;
-        this.excludeTotalExpenses = excludeTotalExpenses != false ? excludeTotalExpenses : this.excludeTotalExpenses;
     }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/entity/Expense.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/entity/Expense.java
@@ -42,4 +42,13 @@ public class Expense {
         this.user = user;
         this.excludeTotalExpenses = excludeTotalExpenses;
     }
+
+    public void update(LocalDateTime spendingTime, Long expenses
+            , Category category, String memo, boolean excludeTotalExpenses) {
+        this.spendingTime = spendingTime != null ? spendingTime : this.spendingTime;
+        this.expenses = expenses != null ? expenses : this.expenses;
+        this.category = category != null ? category : this.category;
+        this.memo = memo != null ? memo : this.memo;
+        this.excludeTotalExpenses = excludeTotalExpenses != false ? excludeTotalExpenses : this.excludeTotalExpenses;
+    }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/entity/Expense.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/entity/Expense.java
@@ -3,6 +3,7 @@ package com.budgetplanner.BudgetPlanner.expense.entity;
 import com.budgetplanner.BudgetPlanner.budget.entity.Category;
 import com.budgetplanner.BudgetPlanner.user.entity.User;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,6 +29,12 @@ public class Expense {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
-
-
+    @Builder
+    public Expense(LocalDateTime spendingTime, Long expenses, Category category, String memo, User user) {
+        this.spendingTime = spendingTime;
+        this.expenses = expenses;
+        this.category = category;
+        this.memo = memo;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/entity/Expense.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/entity/Expense.java
@@ -50,4 +50,12 @@ public class Expense {
         this.category = category != null ? category : this.category;
         this.memo = memo != null ? memo : this.memo;
     }
+
+    public void exclude() {
+        if (this.excludeTotalExpenses == true) {
+            this.excludeTotalExpenses = false;
+        } else {
+            this.excludeTotalExpenses = true;
+        }
+    }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/entity/Expense.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/entity/Expense.java
@@ -1,0 +1,33 @@
+package com.budgetplanner.BudgetPlanner.expense.entity;
+
+import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import com.budgetplanner.BudgetPlanner.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Expense {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    //지출 일시
+    private LocalDateTime spendingTime;
+
+    private Long expenses;
+
+    private Category category;
+
+    private String memo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+
+
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/entity/Expense.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/entity/Expense.java
@@ -29,12 +29,17 @@ public class Expense {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
+    //지출 합계 제외
+    private boolean excludeTotalExpenses;
+
     @Builder
-    public Expense(LocalDateTime spendingTime, Long expenses, Category category, String memo, User user) {
+    public Expense(LocalDateTime spendingTime, Long expenses, Category category, String memo, User user,
+                   boolean excludeTotalExpenses) {
         this.spendingTime = spendingTime;
         this.expenses = expenses;
         this.category = category;
         this.memo = memo;
         this.user = user;
+        this.excludeTotalExpenses = excludeTotalExpenses;
     }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/repository/ExpenseRepository.java
@@ -4,10 +4,11 @@ import com.budgetplanner.BudgetPlanner.expense.entity.Expense;
 import com.budgetplanner.BudgetPlanner.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
-    List<Expense> findByUser(User user);
+    List<Expense> findBySpendingTimeBetweenAndUser(LocalDateTime startTime, LocalDateTime endTime, User user);
 }
+

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/repository/ExpenseRepository.java
@@ -1,0 +1,7 @@
+package com.budgetplanner.BudgetPlanner.expense.repository;
+
+import com.budgetplanner.BudgetPlanner.expense.entity.Expense;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/repository/ExpenseRepository.java
@@ -1,7 +1,13 @@
 package com.budgetplanner.BudgetPlanner.expense.repository;
 
 import com.budgetplanner.BudgetPlanner.expense.entity.Expense;
+import com.budgetplanner.BudgetPlanner.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+
+    List<Expense> findByUser(User user);
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
@@ -4,6 +4,7 @@ import com.budgetplanner.BudgetPlanner.common.exception.CustomException;
 import com.budgetplanner.BudgetPlanner.common.exception.ErrorCode;
 import com.budgetplanner.BudgetPlanner.expense.dto.CreateExpenseRequest;
 import com.budgetplanner.BudgetPlanner.expense.dto.GetExpenseResponse;
+import com.budgetplanner.BudgetPlanner.expense.dto.GetExpensesResponse;
 import com.budgetplanner.BudgetPlanner.expense.entity.Expense;
 import com.budgetplanner.BudgetPlanner.expense.repository.ExpenseRepository;
 import com.budgetplanner.BudgetPlanner.user.entity.User;
@@ -14,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -64,5 +67,15 @@ public class ExpenseService {
         if (!expense.getUser().getAccount().equals(authentication.getName())) {
             throw new CustomException(ErrorCode.EXPENSE_USER_MISMATCH);
         }
+    }
+
+    public List<GetExpensesResponse> getExpenses(Authentication authentication) {
+
+        User user = userRepository.findByAccount(authentication.getName())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return expenseRepository.findByUser(user).stream()
+                .map(GetExpensesResponse::new)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
@@ -15,7 +15,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -35,7 +34,7 @@ public class ExpenseService {
         Expense expense = Expense.builder()
                 .expenses(request.getExpenses())
                 .category(request.getCategory())
-                .spendingTime(LocalDateTime.now())
+                .spendingTime(request.getSpendingTime())
                 .memo(request.getMemo())
                 .user(user)
                 .excludeTotalExpenses(false)

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
@@ -101,4 +101,17 @@ public class ExpenseService {
 
         expenseRepository.deleteById(id);
     }
+
+    @Transactional
+    public void exclude(Long id, Authentication authentication) {
+        User user = userRepository.findByAccount(authentication.getName())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Expense expense = expenseRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.EXPENSE_NOT_FOUND));
+
+        matchUser(authentication, expense);
+
+        expense.exclude();
+    }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
@@ -33,6 +33,7 @@ public class ExpenseService {
                 .spendingTime(LocalDateTime.now())
                 .memo(request.getMemo())
                 .user(user)
+                .excludeTotalExpenses(false)
                 .build();
 
         expenseRepository.save(expense);

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
@@ -3,6 +3,7 @@ package com.budgetplanner.BudgetPlanner.expense.service;
 import com.budgetplanner.BudgetPlanner.common.exception.CustomException;
 import com.budgetplanner.BudgetPlanner.common.exception.ErrorCode;
 import com.budgetplanner.BudgetPlanner.expense.dto.CreateExpenseRequest;
+import com.budgetplanner.BudgetPlanner.expense.dto.GetExpenseResponse;
 import com.budgetplanner.BudgetPlanner.expense.entity.Expense;
 import com.budgetplanner.BudgetPlanner.expense.repository.ExpenseRepository;
 import com.budgetplanner.BudgetPlanner.user.entity.User;
@@ -37,5 +38,31 @@ public class ExpenseService {
                 .build();
 
         expenseRepository.save(expense);
+    }
+
+    public GetExpenseResponse getExpense(Long id, Authentication authentication) {
+
+        Expense expense = expenseRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.EXPENSE_NOT_FOUND));
+
+        matchUser(authentication, expense);
+
+        GetExpenseResponse response = GetExpenseResponse.builder()
+                .id(expense.getId())
+                .userId(expense.getUser().getId())
+                .category(expense.getCategory())
+                .expenses(expense.getExpenses())
+                .spendingTime(expense.getSpendingTime())
+                .memo(expense.getMemo())
+                .excludeTotalExpenses(expense.isExcludeTotalExpenses())
+                .build();
+
+        return response;
+    }
+
+    private void matchUser(Authentication authentication, Expense expense) {
+        if (!expense.getUser().getAccount().equals(authentication.getName())) {
+            throw new CustomException(ErrorCode.EXPENSE_USER_MISMATCH);
+        }
     }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
@@ -5,6 +5,7 @@ import com.budgetplanner.BudgetPlanner.common.exception.ErrorCode;
 import com.budgetplanner.BudgetPlanner.expense.dto.CreateExpenseRequest;
 import com.budgetplanner.BudgetPlanner.expense.dto.GetExpenseResponse;
 import com.budgetplanner.BudgetPlanner.expense.dto.GetExpensesResponse;
+import com.budgetplanner.BudgetPlanner.expense.dto.UpdateExpenseRequest;
 import com.budgetplanner.BudgetPlanner.expense.entity.Expense;
 import com.budgetplanner.BudgetPlanner.expense.repository.ExpenseRepository;
 import com.budgetplanner.BudgetPlanner.user.entity.User;
@@ -77,5 +78,18 @@ public class ExpenseService {
         return expenseRepository.findByUser(user).stream()
                 .map(GetExpensesResponse::new)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void update(Long id, Authentication authentication, UpdateExpenseRequest request) {
+
+        userRepository.findByAccount(authentication.getName())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Expense expense = expenseRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.EXPENSE_NOT_FOUND));
+
+        expense.update(request.getSpendingTime(), request.getExpenses(),
+                request.getCategory(), request.getMemo(), request.isExcludeTotalExpenses());
     }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
@@ -90,7 +90,7 @@ public class ExpenseService {
 
 
         expense.update(request.getSpendingTime(), request.getExpenses(),
-                request.getCategory(), request.getMemo(), request.isExcludeTotalExpenses());
+                request.getCategory(), request.getMemo());
     }
 
 

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
@@ -1,0 +1,40 @@
+package com.budgetplanner.BudgetPlanner.expense.service;
+
+import com.budgetplanner.BudgetPlanner.common.exception.CustomException;
+import com.budgetplanner.BudgetPlanner.common.exception.ErrorCode;
+import com.budgetplanner.BudgetPlanner.expense.dto.CreateExpenseRequest;
+import com.budgetplanner.BudgetPlanner.expense.entity.Expense;
+import com.budgetplanner.BudgetPlanner.expense.repository.ExpenseRepository;
+import com.budgetplanner.BudgetPlanner.user.entity.User;
+import com.budgetplanner.BudgetPlanner.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ExpenseService {
+
+    private final ExpenseRepository expenseRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void create(CreateExpenseRequest request, Authentication authentication) {
+
+        User user = userRepository.findByAccount(authentication.getName())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Expense expense = Expense.builder()
+                .expenses(request.getExpenses())
+                .category(request.getCategory())
+                .spendingTime(LocalDateTime.now())
+                .memo(request.getMemo())
+                .user(user)
+                .build();
+
+        expenseRepository.save(expense);
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
@@ -88,6 +88,7 @@ public class ExpenseService {
         Expense expense = expenseRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.EXPENSE_NOT_FOUND));
 
+        matchUser(authentication, expense);
 
         expense.update(request.getSpendingTime(), request.getExpenses(),
                 request.getCategory(), request.getMemo());

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
@@ -88,7 +88,17 @@ public class ExpenseService {
         Expense expense = expenseRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.EXPENSE_NOT_FOUND));
 
+
         expense.update(request.getSpendingTime(), request.getExpenses(),
                 request.getCategory(), request.getMemo(), request.isExcludeTotalExpenses());
+    }
+
+
+    @Transactional
+    public void delete(Long id, Authentication authentication) {
+        userRepository.findByAccount(authentication.getName())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        expenseRepository.deleteById(id);
     }
 }


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

- 유저는 자신이 사용한 지출을 기록합니다.
- 기본적인 CRUD를 구현하였습니다.
- 전체 조회는 필수적으로 `기간`으로 조회합니다.
- 조회에는 `모든 지출의 합계` 및 `카테고리 별 지출 합계`를 반환합니다.
- `특정 카테고리`만 조회가 가능합니다. (required = false)
- `최소, 최대 금액`으로 조회가 가능합니다.(required = false)
- 합계 제외 지출은 목록에 `포함`되지만, 지출 합계에서는 `제외`됩니다.

## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## 📸 스크린샷


## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.

## 📎 관련 이슈

#15 

## 🙌 리뷰 및 피드백
