### PR TITLE
feat: 오늘 지출 추천 API 구현

### DIFF
--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/repository/BudgetRepository.java
@@ -1,6 +1,7 @@
 package com.budgetplanner.BudgetPlanner.budget.repository;
 
 import com.budgetplanner.BudgetPlanner.budget.entity.Budget;
+import com.budgetplanner.BudgetPlanner.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -10,4 +11,6 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
 
     @Query("SELECT b.category, SUM(b.budget) FROM Budget b GROUP BY b.category")
     List<Object[]> findCategoryAndBudget();
+
+    List<Budget> findByUser(User user);
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/common/exception/ErrorCode.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/common/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
 
     //budget
     CATEGORY_MISSING(HttpStatus.BAD_REQUEST, "B001", "카테고리에 대한 예산을 모두 입력해주세요."),
+    BUDGET_NOT_FOUND(HttpStatus.NOT_FOUND, "B002", "설정된 예산이 없습니다."),
 
     //expense
     EXPENSE_NOT_FOUND(HttpStatus.NOT_FOUND, "E001", "해당 지출을 찾을 수 없습니다."),

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/CreateExpenseRequest.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/CreateExpenseRequest.java
@@ -3,11 +3,14 @@ package com.budgetplanner.BudgetPlanner.expense.dto;
 import com.budgetplanner.BudgetPlanner.budget.entity.Category;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor
 public class CreateExpenseRequest {
 
     @NotNull(message = "지출 비용은 필수입니다.")
@@ -21,4 +24,12 @@ public class CreateExpenseRequest {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     @NotNull(message = "지출 시간은 필수입니다.")
     private LocalDateTime spendingTime;
+
+    @Builder
+    public CreateExpenseRequest(Long expenses, Category category, String memo, LocalDateTime spendingTime) {
+        this.expenses = expenses;
+        this.category = category;
+        this.memo = memo;
+        this.spendingTime = spendingTime;
+    }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/GetExpensesResponse.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/GetExpensesResponse.java
@@ -27,4 +27,14 @@ public class GetExpensesResponse {
         this.memo = expense.getMemo();
         this.excludeTotalExpenses = expense.isExcludeTotalExpenses();
     }
+
+    @Builder
+    public GetExpensesResponse(Long id, Category category, Long expenses, LocalDateTime spendingTime, String memo, boolean excludeTotalExpenses) {
+        this.id = id;
+        this.category = category;
+        this.expenses = expenses;
+        this.spendingTime = spendingTime;
+        this.memo = memo;
+        this.excludeTotalExpenses = excludeTotalExpenses;
+    }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/UpdateExpenseRequest.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/UpdateExpenseRequest.java
@@ -2,11 +2,14 @@ package com.budgetplanner.BudgetPlanner.expense.dto;
 
 import com.budgetplanner.BudgetPlanner.budget.entity.Category;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor
 public class UpdateExpenseRequest {
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
@@ -15,4 +18,12 @@ public class UpdateExpenseRequest {
     private Long expenses;
     private Category category;
     private String memo;
+
+    @Builder
+    public UpdateExpenseRequest(LocalDateTime spendingTime, Long expenses, Category category, String memo) {
+        this.spendingTime = spendingTime;
+        this.expenses = expenses;
+        this.category = category;
+        this.memo = memo;
+    }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expenseadvisor/controller/ExpenseAdvisorController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expenseadvisor/controller/ExpenseAdvisorController.java
@@ -1,0 +1,29 @@
+package com.budgetplanner.BudgetPlanner.expenseadvisor.controller;
+
+import com.budgetplanner.BudgetPlanner.expenseadvisor.dto.BudgetRecommendationResponse;
+import com.budgetplanner.BudgetPlanner.expenseadvisor.service.ExpenseAdvisorService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/expense-advisor")
+public class ExpenseAdvisorController {
+
+    private final ExpenseAdvisorService expenseAdvisorService;
+
+    @GetMapping("/recommend")
+    public ResponseEntity<?> recommend(Authentication authentication) {
+
+        BudgetRecommendationResponse response = expenseAdvisorService.getRecommendation(authentication);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expenseadvisor/dto/BudgetRecommendationResponse.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expenseadvisor/dto/BudgetRecommendationResponse.java
@@ -1,0 +1,25 @@
+package com.budgetplanner.BudgetPlanner.expenseadvisor.dto;
+
+import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+public class BudgetRecommendationResponse {
+
+    private int dailyAmount;
+    private Map<Category, Integer> categoryBudgets;
+    private String comment;
+
+    @Builder
+    public BudgetRecommendationResponse(int dailyAmount, Map<Category, Integer> categoryBudgets,
+                                        String comment) {
+        this.dailyAmount = dailyAmount;
+        this.categoryBudgets = categoryBudgets;
+        this.comment = comment;
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expenseadvisor/service/ExpenseAdvisorService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expenseadvisor/service/ExpenseAdvisorService.java
@@ -1,0 +1,122 @@
+package com.budgetplanner.BudgetPlanner.expenseadvisor.service;
+
+import com.budgetplanner.BudgetPlanner.budget.entity.Budget;
+import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import com.budgetplanner.BudgetPlanner.budget.repository.BudgetRepository;
+import com.budgetplanner.BudgetPlanner.common.exception.CustomException;
+import com.budgetplanner.BudgetPlanner.common.exception.ErrorCode;
+import com.budgetplanner.BudgetPlanner.expense.dto.GetExpensesResponse;
+import com.budgetplanner.BudgetPlanner.expense.entity.Expense;
+import com.budgetplanner.BudgetPlanner.expense.repository.ExpenseRepository;
+import com.budgetplanner.BudgetPlanner.expenseadvisor.dto.BudgetRecommendationResponse;
+import com.budgetplanner.BudgetPlanner.user.entity.User;
+import com.budgetplanner.BudgetPlanner.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ExpenseAdvisorService {
+
+    private final UserRepository userRepository;
+    private final BudgetRepository budgetRepository;
+    private final ExpenseRepository expenseRepository;
+
+    private static final int DAILY_MIN_BUDGET = 10000;
+    private static String comment = "";
+
+
+    public BudgetRecommendationResponse getRecommendation(Authentication authentication) {
+
+        User user = userRepository.findByAccount(authentication.getName())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        List<Budget> budgets = budgetRepository.findByUser(user);
+
+        //남은 일수 계산
+        int remainingDays = calculateRemainingDays();
+
+        //유저의 설정된 예산
+        long budget = getBudgets(budgets);
+
+        //유저가 이제까지 쓴 금액
+        long spentAmount = amountUsedThisMonth(user);
+
+        //오늘 지출 가능한 금액
+        int dailyAmount = (int)Math.floor((double)(budget - spentAmount) / remainingDays / 100) * 100;
+
+        if (dailyAmount < DAILY_MIN_BUDGET) {
+            dailyAmount = DAILY_MIN_BUDGET;
+            comment = "이번 달 소비가 많습니다. 오늘은 절약하시는 것을 추천드립니다! 화이팅!";
+        } else {
+            comment = "이번 달 소비 계획이 잘 지켜지고 있습니다!";
+        }
+
+        //유저 예산 비율 구하기
+        Map<Category, Double> categoryRatios = calculateCategoryRatios(budgets, budget);
+
+        //카테고리별 사용 가능한 유저 예산
+        Map<Category, Integer> categoryBudgets = getCategoryBudgets(budgets, dailyAmount, categoryRatios);
+
+        return BudgetRecommendationResponse.builder()
+                .dailyAmount(dailyAmount)
+                .categoryBudgets(categoryBudgets)
+                .comment(comment)
+                .build();
+
+    }
+
+    private Map<Category, Integer> getCategoryBudgets(List<Budget> budgets, int dailyAmount, Map<Category, Double> categoryRatios) {
+        return budgets.stream()
+                .collect(Collectors.toMap(
+                        Budget::getCategory,
+                        b -> (int) (Math.floor(dailyAmount * categoryRatios.get(b.getCategory()) / 100) * 100)
+                ));
+    }
+
+    private Map<Category, Double> calculateCategoryRatios(List<Budget> budgets, long budget) {
+        Map<Category, Double> categoryRatios = budgets.stream()
+                .collect(Collectors.toMap(
+                        Budget::getCategory,
+                        b -> (double) b.getBudget() / budget
+                ));
+        return categoryRatios;
+    }
+
+    private long getBudgets(List<Budget> budgets) {
+        long budget = budgets.stream()
+                .mapToLong(Budget::getBudget)
+                .sum();
+        return budget;
+    }
+
+    private long amountUsedThisMonth(User user) {
+        LocalDateTime startOfMonth = LocalDateTime.of(LocalDate.now().withDayOfMonth(1), LocalTime.MIN);
+        LocalDateTime yesterday = LocalDateTime.now().minusDays(1).with(LocalTime.MAX);
+
+
+        long spentAmount = expenseRepository.findBySpendingTimeBetweenAndUser(startOfMonth, yesterday, user).stream()
+                .filter(expense -> !expense.isExcludeTotalExpenses())
+                .mapToLong(Expense::getExpenses)
+                .sum();
+        return spentAmount;
+    }
+
+    private int calculateRemainingDays() {
+        LocalDate today = LocalDate.now();
+        LocalDate lastDayOfMonth = today.withDayOfMonth(today.lengthOfMonth());
+
+        long remainingDays = ChronoUnit.DAYS.between(today, lastDayOfMonth);
+
+        return (int) remainingDays;
+    }
+}

--- a/src/test/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseControllerTest.java
+++ b/src/test/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseControllerTest.java
@@ -1,0 +1,183 @@
+package com.budgetplanner.BudgetPlanner.expense.controller;
+
+import com.budgetplanner.BudgetPlanner.auth.controller.AuthController;
+import com.budgetplanner.BudgetPlanner.auth.filter.JwtAuthenticationFilter;
+import com.budgetplanner.BudgetPlanner.auth.jwt.JwtUtils;
+import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import com.budgetplanner.BudgetPlanner.expense.dto.CreateExpenseRequest;
+import com.budgetplanner.BudgetPlanner.expense.dto.GetExpenseResponse;
+import com.budgetplanner.BudgetPlanner.expense.dto.GetExpensesResponse;
+import com.budgetplanner.BudgetPlanner.expense.dto.UpdateExpenseRequest;
+import com.budgetplanner.BudgetPlanner.expense.entity.Expense;
+import com.budgetplanner.BudgetPlanner.expense.service.ExpenseService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ExpenseController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtils.class)
+        })
+class ExpenseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ExpenseService expenseService;
+
+    @DisplayName("지출 생성")
+    @WithMockUser
+    @Test
+    void createExpense() throws Exception {
+
+        CreateExpenseRequest request = CreateExpenseRequest.builder()
+                .expenses(100000L)
+                .category(Category.HOUSING_EXPENSES)
+                .memo("점심 값")
+                .spendingTime(LocalDateTime.parse("2023-11-21 10:30", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .build();
+
+        String json = objectMapper.writeValueAsString(request);
+
+        mockMvc.perform(post("/api/expense").with(csrf())
+                .contentType(APPLICATION_JSON)
+                .content(json))
+                .andDo(print())
+                .andExpect(status().isCreated());
+    }
+
+//    @DisplayName("지출 전체 조회")
+//    @WithMockUser
+//    @Test
+//    void getExpenses() throws Exception {
+//        //todo 전체 조회 수정해야함!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+//        GetExpensesResponse expense1 = GetExpensesResponse.builder()
+//                .id(1L)
+//                .category(Category.HOUSING_EXPENSES)
+//                .expenses(100000L)
+//                .memo("저녁 값")
+//                .spendingTime(LocalDateTime.parse("2023-11-21 10:30", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+//                .excludeTotalExpenses(false)
+//                .build();
+//
+//        GetExpensesResponse expense2 = GetExpensesResponse.builder()
+//                .id(2L)
+//                .category(Category.HOUSING_EXPENSES)
+//                .expenses(200000L)
+//                .memo("점심 값")
+//                .spendingTime(LocalDateTime.parse("2023-11-21 11:30", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+//                .excludeTotalExpenses(false)
+//                .build();
+//
+//        List<GetExpensesResponse> response = Stream.of(expense1, expense2).collect(Collectors.toList());
+//
+//        when(expenseService.getExpenses(any())).thenReturn(response);
+//
+//        mockMvc.perform(get("/api/expense").with(csrf()))
+//                .andDo(print())
+//                .andExpect(status().isOk());
+//    }
+
+    @DisplayName("지출 단건 조회")
+    @WithMockUser
+    @Test
+    void getExpense() throws Exception {
+
+        GetExpenseResponse response = GetExpenseResponse.builder()
+                .id(1L)
+                .userId(1L)
+                .category(Category.HOUSING_EXPENSES)
+                .expenses(100000L)
+                .memo("저녁 값")
+                .spendingTime(LocalDateTime.parse("2023-11-21 10:30", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .excludeTotalExpenses(false)
+                .build();
+
+        when(expenseService.getExpense(any(), any())).thenReturn(response);
+
+        mockMvc.perform(get("/api/expense/{id}", 1).with(csrf()))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("지출 변경")
+    @WithMockUser
+    @Test
+    void updateExpense() throws Exception {
+
+        UpdateExpenseRequest request = UpdateExpenseRequest.builder()
+                .expenses(1000L)
+                .category(Category.FOOD_EXPENSES)
+                .memo("수정 저녁 값")
+                .spendingTime(LocalDateTime.parse("2023-11-21 11:30", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .build();
+
+        doNothing().when(expenseService).update(anyLong(), any(Authentication.class), any(UpdateExpenseRequest.class));
+
+        mockMvc.perform(patch("/api/expense/{id}", 1)
+                        .with(csrf())
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+
+    @DisplayName("지출 삭제")
+    @WithMockUser
+    @Test
+    void deleteExpense() throws Exception {
+
+        doNothing().when(expenseService).delete(any(), any(Authentication.class));
+
+        mockMvc.perform(delete("/api/expense/{id}", 1)
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+
+    @DisplayName("지출 - 합계제외 상태 변경")
+    @WithMockUser
+    @Test
+    void excludeExpense() throws Exception {
+
+        doNothing().when(expenseService).exclude(any(), any(Authentication.class));
+
+        mockMvc.perform(patch("/api/expense/{id}/exclude", 1)
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+}


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

- 설정한 `월별` 예산을 만족하기 위해 오늘 지출 가능한 금액을 `총액 과 `카테고리 별 금액`으로 제공합니다.
- 고려사항 1. 앞선 일자에서 과다 소비하였다 해서 오늘 예산을 극히 줄이는것이 아니라, 이후 일자에 부담을 분배한다.
- 고려사항 2. 기간 전체 예산을 초과 하더라도 0원 또는 음수 의 예산을 추천받지 않아야 한다.
- 유저의 상황에 맞는 한 문장의 멘트 노출.

- 추가로 Scheduler or Discord webhook, 이메일, 카카오톡 알림 구현할 예정!

## 📋 변경 사항

- [x] 새로운 기능 추가

## 📸 스크린샷

(선택 사항: 변경된 내용을 시각적으로 보여주기 위해 스크린샷을 첨부하세요.)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.

## 📎 관련 이슈

#18 

## 🙌 리뷰 및 피드백
