### PR TITLE
feat: 통계 API 구현

### DIFF
--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/repository/ExpenseRepository.java
@@ -10,5 +10,6 @@ import java.util.List;
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
     List<Expense> findBySpendingTimeBetweenAndUser(LocalDateTime startTime, LocalDateTime endTime, User user);
-}
 
+    List<Expense> findBySpendingTimeBetween(LocalDateTime startTime, LocalDateTime endTime);
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/statistics/controller/StatisticsController.java
@@ -1,0 +1,28 @@
+package com.budgetplanner.BudgetPlanner.statistics.controller;
+
+import com.budgetplanner.BudgetPlanner.statistics.dto.StatisticsResponse;
+import com.budgetplanner.BudgetPlanner.statistics.service.StatisticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/statistics")
+public class StatisticsController {
+
+    private final StatisticsService statisticsService;
+
+    @GetMapping
+    public ResponseEntity<?> getStatistics(@RequestParam("data") String data,
+                                           Authentication authentication) {
+        StatisticsResponse response = statisticsService.getStatistics(data, authentication);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/statistics/dto/StatisticsResponse.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/statistics/dto/StatisticsResponse.java
@@ -1,0 +1,23 @@
+package com.budgetplanner.BudgetPlanner.statistics.dto;
+
+import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+public class StatisticsResponse {
+
+    private Integer compareTotalPercent;
+    private Map<Category, String> compareCategoryPercent;
+
+    @Builder
+    public StatisticsResponse(Integer compareTotalPercent,
+                              Map<Category, String> compareCategoryPercent) {
+        this.compareTotalPercent = compareTotalPercent;
+        this.compareCategoryPercent = compareCategoryPercent;
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/statistics/service/StatisticsService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/statistics/service/StatisticsService.java
@@ -1,0 +1,186 @@
+package com.budgetplanner.BudgetPlanner.statistics.service;
+
+import com.budgetplanner.BudgetPlanner.budget.entity.Category;
+import com.budgetplanner.BudgetPlanner.common.exception.CustomException;
+import com.budgetplanner.BudgetPlanner.common.exception.ErrorCode;
+import com.budgetplanner.BudgetPlanner.expense.entity.Expense;
+import com.budgetplanner.BudgetPlanner.expense.repository.ExpenseRepository;
+import com.budgetplanner.BudgetPlanner.statistics.dto.StatisticsResponse;
+import com.budgetplanner.BudgetPlanner.user.entity.User;
+import com.budgetplanner.BudgetPlanner.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StatisticsService {
+
+    private final ExpenseRepository expenseRepository;
+    private final UserRepository userRepository;
+
+    //todo 이번달, 저번달 지출이 없을 시 처리해줘야함 + 리팩토링 필수(지저분, 일단 되게만)
+    public StatisticsResponse getStatistics(String data, Authentication authentication) {
+
+        User user = userRepository.findByAccount(authentication.getName())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        switch (data) {
+            case "last-month":
+                /*
+                * 지난달 지출 총액 가져오기
+                * */
+                //저번달 1일
+                LocalDateTime firstDayOfLastMonth = LocalDateTime.now().minusMonths(1)
+                        .with(TemporalAdjusters.firstDayOfMonth()).with(LocalTime.MIN);
+                //현재 날짜 - 1달
+                LocalDateTime aMonthAgo = LocalDateTime.now().minusMonths(1);
+
+                List<Expense> lastMonthExpenses = expenseRepository.findBySpendingTimeBetweenAndUser(
+                        firstDayOfLastMonth, aMonthAgo, user);
+
+                //저번달 지출 총액
+                Integer lastMonthTotalSpent = (int) lastMonthExpenses.stream()
+                        .filter(expense -> !expense.isExcludeTotalExpenses())
+                        .mapToLong(Expense::getExpenses)
+                        .sum();
+                /*
+                * 이번달 지출 총액 가져오기
+                * */
+
+                //이번달 1일
+                LocalDateTime firstDayOfMonth = LocalDateTime.now()
+                        .with(TemporalAdjusters.firstDayOfMonth()).with(LocalTime.MIN);
+
+                //현재
+                LocalDateTime now = LocalDateTime.now();
+
+                List<Expense> thisMonthExpenses = expenseRepository.findBySpendingTimeBetweenAndUser(
+                        firstDayOfMonth, now, user);
+
+                //이번달 지출 총액
+                Integer thisMonthTotalSpent = (int) thisMonthExpenses.stream()
+                        .filter(expense -> !expense.isExcludeTotalExpenses())
+                        .mapToLong(Expense::getExpenses)
+                        .sum();
+
+                //저번달 대비 이번달 소비율
+                int compareTotalPercent = (int) ((double) thisMonthTotalSpent / lastMonthTotalSpent * 100);
+
+                //지난달 카테고리 별 지출 총액 가져오기
+                Map<Category, Long> lastMonthCategoryTotalSpent = lastMonthExpenses.stream()
+                        .collect(Collectors.groupingBy(
+                                Expense::getCategory,
+                                LinkedHashMap::new, //순서보장
+                                Collectors.summingLong(Expense::getExpenses)
+                        ));
+
+                //이번달 카테고리 별 지출 총액 가져오기
+                Map<Category, Long> thisMonthCategoryTotalSpent = thisMonthExpenses.stream()
+                        .collect(Collectors.groupingBy(
+                                Expense::getCategory,
+                                LinkedHashMap::new, //순서보장
+                                Collectors.summingLong(Expense::getExpenses)
+                        ));
+
+                //비교해서 퍼센티지
+                Map<Category, String> compareCategoryPercent = new HashMap<>();
+
+                lastMonthCategoryTotalSpent.forEach((category, lastMonthTotal) -> {
+                    // 이번 달의 카테고리별 총 지출
+                    long thisMonthTotal = thisMonthCategoryTotalSpent.getOrDefault(category, 0L);
+
+                    // 저번 달 대비 이번 달 지출 비율 계산
+                    int ratio = (int) ((double) thisMonthTotal / lastMonthTotal * 100);
+
+                    // 결과 맵에 추가
+                    compareCategoryPercent.put(category, String.format("%d%%", ratio));
+                });
+
+                return StatisticsResponse.builder()
+                        .compareTotalPercent(compareTotalPercent)
+                        .compareCategoryPercent(compareCategoryPercent)
+                        .build();
+
+            case "last-week":
+                //-7일 전 하루 지출 총액가져오기
+                //저번달 1일
+                LocalDateTime aWeekAgoStart = LocalDateTime.now().minusDays(7).with(LocalTime.MIN);
+                //현재 날짜 - 1달
+                LocalDateTime aWeekAgoEnd = LocalDateTime.now().minusDays(7).with(LocalTime.MAX);
+
+                List<Expense> aWeekAgoExpenses = expenseRepository.findBySpendingTimeBetweenAndUser(
+                        aWeekAgoStart, aWeekAgoEnd, user);
+
+                //일주일 전(하루) 지출
+                Integer aWeekAgoTotalSpent = (int) aWeekAgoExpenses.stream()
+                        .filter(expense -> !expense.isExcludeTotalExpenses())
+                        .mapToLong(Expense::getExpenses)
+                        .sum();
+                //오늘 하루 지출 총액가져오기
+
+                LocalDateTime todayStart = LocalDateTime.now().with(LocalTime.MIN);
+                LocalDateTime todayNow = LocalDateTime.now();
+
+                List<Expense> todayExpenses = expenseRepository.findBySpendingTimeBetweenAndUser(todayStart, todayNow, user);
+
+                Integer todayTotalSpent = (int) todayExpenses.stream()
+                        .filter(expense -> !expense.isExcludeTotalExpenses())
+                        .mapToLong(Expense::getExpenses)
+                        .sum();
+
+                //비교해서 퍼센티지
+                int compareTodayTotalPercent = (int) ((double) todayTotalSpent / aWeekAgoTotalSpent * 100);
+
+                return StatisticsResponse.builder()
+                        .compareTotalPercent(compareTodayTotalPercent)
+                        .build();
+
+            case "other-user":
+                //다른 유저들의 이번달 지출 가져와서 평균내기
+                //이번달 1일
+                LocalDateTime start = LocalDateTime.now()
+                        .with(TemporalAdjusters.firstDayOfMonth()).with(LocalTime.MIN);
+                //현재
+                LocalDateTime end = LocalDateTime.now();
+
+                List<Expense> findUser = expenseRepository.findBySpendingTimeBetweenAndUser(start, end, user);
+
+                Long findUserTotalSpent = findUser.stream()
+                        .filter(expense -> !expense.isExcludeTotalExpenses())
+                        .collect(Collectors.summingLong(Expense::getExpenses));
+
+                List<Expense> users = expenseRepository.findBySpendingTimeBetween(start, end);
+
+                Map<User, Long> usersExpenses = users.stream()
+                        .collect(Collectors.groupingBy(
+                                Expense::getUser,
+                                Collectors.summingLong(Expense::getExpenses)
+                        ));
+
+                Long totalSpent = 0L;
+                for (Long value : usersExpenses.values()) {
+                    totalSpent += value;
+                }
+
+                double average = ((double) totalSpent / usersExpenses.size());
+
+                int compareAverage = (int)((double) findUserTotalSpent / average * 100);
+
+                return StatisticsResponse.builder()
+                        .compareTotalPercent(compareAverage)
+                        .build();
+
+        }
+        throw new IllegalArgumentException(); //todo 추후 변경
+    }
+}


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

- `지난 달` 대비 `총액`, `카테고리 별` 소비율.
    - 오늘이 10일차 라면, 지난달 10일차 까지의 데이터를 대상으로 비교
    - ex) `식비` 지난달 대비 150%
- `지난 요일` 대비 소비율
    - 오늘이 `월요일` 이라면 지난 `월요일 요청 시간까지` 에 소비한 모든 기록 대비 소비율
    - ex) `월요일` 평소 대비 80%
- `다른 유저` 대비 소비율
    - 오늘 기준 다른 `유저` 가 예산 대비 사용한 평균 비율 대비 나의 소비율
    - 오늘기준 다른 유저가 소비한 지출이 평균 50%(ex. 예산 100만원 중 50만원 소비중) 이고 나는 60% 이면 120%.
    - ex) `다른 사용자` 대비 120%

## 📋 변경 사항

- [x] 새로운 기능 추가
## 📸 스크린샷

(선택 사항: 변경된 내용을 시각적으로 보여주기 위해 스크린샷을 첨부하세요.)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#31 
