### PR TITLE
refactor: Expense 리팩토링 및 쿼리 최적화

### DIFF
--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/controller/ExpenseController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "지출", description = "지출 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/expense")
+@RequestMapping("/api/expenses")
 public class ExpenseController {
 
     private final ExpenseService expenseService;

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/repository/ExpenseRepository.java
@@ -3,13 +3,19 @@ package com.budgetplanner.BudgetPlanner.expense.repository;
 import com.budgetplanner.BudgetPlanner.expense.entity.Expense;
 import com.budgetplanner.BudgetPlanner.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
     List<Expense> findBySpendingTimeBetweenAndUser(LocalDateTime startTime, LocalDateTime endTime, User user);
 
     List<Expense> findBySpendingTimeBetween(LocalDateTime startTime, LocalDateTime endTime);
+
+    @Query("select e from Expense e join fetch e.user where e.id = :id")
+    Optional<Expense> findByIdWithUser(@Param("id") Long id);
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
@@ -63,12 +63,6 @@ public class ExpenseService {
         return response;
     }
 
-    private void matchUser(Authentication authentication, Expense expense) {
-        if (!expense.getUser().getAccount().equals(authentication.getName())) {
-            throw new CustomException(ErrorCode.EXPENSE_USER_MISMATCH);
-        }
-    }
-
     public ResultExpensesResponse getExpenses(Authentication authentication, ParamsRequest request) {
         User user = userRepository.findByAccount(authentication.getName())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -98,17 +92,6 @@ public class ExpenseService {
                 .build();
     }
 
-    private boolean isCategoryMatch(ParamsRequest request, GetExpensesResponse expense) {
-        return request.category() == null || expense.getCategory() == request.category();
-    }
-
-    private boolean isAmountInRange(ParamsRequest request, GetExpensesResponse expense) {
-        boolean minCondition = request.min() == null || expense.getExpenses() >= request.min();
-        boolean maxCondition = request.max() == null || expense.getExpenses() <= request.max();
-        return minCondition && maxCondition;
-    }
-
-
     @Transactional
     public void update(Long id, Authentication authentication, UpdateExpenseRequest request) {
 
@@ -123,7 +106,6 @@ public class ExpenseService {
         expense.update(request.getSpendingTime(), request.getExpenses(),
                 request.getCategory(), request.getMemo());
     }
-
 
     @Transactional
     public void delete(Long id, Authentication authentication) {
@@ -144,5 +126,21 @@ public class ExpenseService {
         matchUser(authentication, expense);
 
         expense.exclude();
+    }
+
+    private boolean isCategoryMatch(ParamsRequest request, GetExpensesResponse expense) {
+        return request.category() == null || expense.getCategory() == request.category();
+    }
+
+    private boolean isAmountInRange(ParamsRequest request, GetExpensesResponse expense) {
+        boolean minCondition = request.min() == null || expense.getExpenses() >= request.min();
+        boolean maxCondition = request.max() == null || expense.getExpenses() <= request.max();
+        return minCondition && maxCondition;
+    }
+
+    private void matchUser(Authentication authentication, Expense expense) {
+        if (!expense.getUser().getAccount().equals(authentication.getName())) {
+            throw new CustomException(ErrorCode.EXPENSE_USER_MISMATCH);
+        }
     }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
@@ -45,7 +45,7 @@ public class ExpenseService {
 
     public GetExpenseResponse getExpense(Long id, Authentication authentication) {
 
-        Expense expense = expenseRepository.findById(id)
+        Expense expense = expenseRepository.findByIdWithUser(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.EXPENSE_NOT_FOUND));
 
         matchUser(authentication, expense);


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

- 엔드포인트 변경 /api/expense -> /api/expenses 복수로 변경
- 메서드 위치 변경 메서드 추출 부분 밑으로 이동
- 단건 조회 쿼리 최적화(페치조인) -> expense를  조회시 user 조회 쿼리 추가 발생 문제를 해결

## 📋 변경 사항

- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 코드 리팩토링

## 📸 스크린샷

- 쿼리 최적화 전
<img width="320" alt="스크린샷 2023-12-19 오후 5 29 34" src="https://github.com/cjw9506/BudgetPlanner/assets/63503519/e07e4630-51bd-416c-a3e5-1b91098fff2f">
<img width="205" alt="스크린샷 2023-12-19 오후 5 29 41" src="https://github.com/cjw9506/BudgetPlanner/assets/63503519/d12dbdea-b493-4a6e-a112-bba12eff11e3">

- 쿼리 최적화 후
<img width="299" alt="스크린샷 2023-12-19 오후 5 28 01" src="https://github.com/cjw9506/BudgetPlanner/assets/63503519/f7867e12-bdb5-4588-a483-c91c6b5168a4">

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 모든 테스트를 통과합니다.

## 📎 관련 이슈

#38 

## 🙌 리뷰 및 피드백

(리뷰어들께 질문하거나 특정 리뷰를 요청하는 내용을 작성하세요.)