### PR TITLE
feat: 토큰 재발급 및 로그아웃 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/controller/AuthController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/controller/AuthController.java
@@ -64,4 +64,13 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    @Operation(summary = "로그아웃", description = "로그아웃")
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(@RequestHeader("Authorization") String token) {
+
+        authService.logout(token);
+
+        return ResponseEntity.status(HttpStatus.OK).body(null);
+    }
+
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/controller/AuthController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/controller/AuthController.java
@@ -66,9 +66,10 @@ public class AuthController {
 
     @Operation(summary = "로그아웃", description = "로그아웃")
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(@RequestHeader("Authorization") String token) {
+    public ResponseEntity<?> logout(@RequestHeader("Authorization") String accessToken,
+                                    @CookieValue("refreshToken") String refreshToken) {
 
-        authService.logout(token);
+        authService.logout(accessToken, refreshToken);
 
         return ResponseEntity.status(HttpStatus.OK).body(null);
     }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/controller/AuthController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/controller/AuthController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "auth", description = "인증 API")
@@ -51,6 +52,16 @@ public class AuthController {
                 .header("Set-Cookie", cookie.toString())
                 .body(response);
 
+    }
+
+    @Operation(summary = "토큰 재발급", description = "토큰 재발급")
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(@CookieValue("refreshToken") String refreshToken,
+                                     Authentication authentication) {
+
+        AccessTokenResponse response = authService.reissue(refreshToken);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/controller/AuthController.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.budgetplanner.BudgetPlanner.auth.controller;
 
+import com.budgetplanner.BudgetPlanner.auth.dto.AccessTokenResponse;
 import com.budgetplanner.BudgetPlanner.auth.dto.AuthenticationResponse;
 import com.budgetplanner.BudgetPlanner.auth.dto.UserLoginRequest;
 import com.budgetplanner.BudgetPlanner.auth.dto.UserSignupRequest;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -33,9 +35,21 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<?> login(@Valid @RequestBody UserLoginRequest request) {
 
-        AuthenticationResponse response = authService.userLogin(request);
+        AuthenticationResponse tokens = authService.userLogin(request);
 
-        return ResponseEntity.status(HttpStatus.OK).body(response);
+        AccessTokenResponse response = AccessTokenResponse.builder()
+                .token(tokens.getAccessToken())
+                .build();
+
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", tokens.getRefreshToken())
+                .httpOnly(true)
+                .path("/")
+                .maxAge(7 * 24 * 60 * 60)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header("Set-Cookie", cookie.toString())
+                .body(response);
 
     }
 

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/dto/AccessTokenResponse.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/dto/AccessTokenResponse.java
@@ -1,0 +1,17 @@
+package com.budgetplanner.BudgetPlanner.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AccessTokenResponse {
+
+    private String token;
+
+    @Builder
+    public AccessTokenResponse(String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/dto/AuthenticationResponse.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/dto/AuthenticationResponse.java
@@ -8,10 +8,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class AuthenticationResponse {
 
-    private String token;
+    private String accessToken;
+    private String refreshToken;
 
     @Builder
-    public AuthenticationResponse(String token) {
-        this.token = token;
+    public AuthenticationResponse(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/filter/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.budgetplanner.BudgetPlanner.auth.filter;
 
 
 import com.budgetplanner.BudgetPlanner.auth.jwt.JwtUtils;
+import com.budgetplanner.BudgetPlanner.token.repository.ExpiredTokenRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,6 +27,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtils jwtUtils;
     private final UserDetailsService userDetailsService;
+    private final ExpiredTokenRepository expiredTokenRepository;
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
@@ -44,6 +46,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
             jwt = authHeader.substring(7);
+
+            if (expiredTokenRepository.isBlackList(jwt)) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
             account = jwtUtils.extractAccount(jwt);
             if (account != null && SecurityContextHolder.getContext().getAuthentication() == null) {
                 UserDetails userDetails = this.userDetailsService.loadUserByUsername(account);

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/jwt/JwtUtils.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/jwt/JwtUtils.java
@@ -17,8 +17,11 @@ import java.util.function.Function;
 @Component
 public class JwtUtils {
 
-    @Value("${jwt.secret.access.key}")
-    private String accessSecretKey;
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+
+    private long accessExpiration = 60 * 60 * 1000;
+    private long refreshExpiration = 60 * 60 * 24 * 7 * 1000;
 
     public String extractAccount(String token) {
         return extractClaim(token, Claims::getSubject);
@@ -29,16 +32,21 @@ public class JwtUtils {
         return claimsResolver.apply(claims);
     }
 
-    public String generateToken(UserDetails userDetails) {
-        return generateToken(new HashMap<>(), userDetails);
+    public String generateAccessToken(UserDetails userDetails) {
+        return generateToken(new HashMap<>(), userDetails, accessExpiration);
     }
 
-    public String generateToken(Map<String, Object> extraClaims, UserDetails userDetails) {
+    public String generateRefreshToken(UserDetails userDetails) {
+        return generateToken(new HashMap<>(), userDetails, refreshExpiration);
+    }
+
+    public String generateToken(Map<String, Object> extraClaims, UserDetails userDetails,
+                                long expiration) {
         return Jwts.builder()
                 .claims(extraClaims)
                 .subject(userDetails.getUsername())
                 .issuedAt(new Date(System.currentTimeMillis()))
-                .expiration(new Date(System.currentTimeMillis() + 60 * 60 * 1000))
+                .expiration(new Date(System.currentTimeMillis() + expiration))
                 .signWith(getSignInKey())
                 .compact();
     }
@@ -65,7 +73,7 @@ public class JwtUtils {
     }
 
     private Key getSignInKey() {
-        byte[] decodedKey = Decoders.BASE64.decode(accessSecretKey);
+        byte[] decodedKey = Decoders.BASE64.decode(secretKey);
         return Keys.hmacShaKeyFor(decodedKey);
     }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/jwt/JwtUtils.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/jwt/JwtUtils.java
@@ -60,7 +60,7 @@ public class JwtUtils {
         return extractExpiration(token).before(new Date());
     }
 
-    private Date extractExpiration(String token) {
+    public Date extractExpiration(String token) {
         return extractClaim(token, Claims::getExpiration);
     }
 

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/service/AuthService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/service/AuthService.java
@@ -92,18 +92,20 @@ public class AuthService {
         throw new CustomException(ErrorCode.INVALID_TOKEN);
     }
 
-    public void logout(String token) {
+    public void logout(String accessToken, String refreshToken) {
 
-        String accessToken = token.substring(7);
-        long expiredTime = jwtUtils.extractExpiration(accessToken).getTime();
+        String AT = accessToken.substring(7);
+
+        long expiredTime = jwtUtils.extractExpiration(AT).getTime();
         long storageTimeMillis = expiredTime - System.currentTimeMillis();
         long StorageTimeSeconds = storageTimeMillis / 1000;
 
         ExpiredToken expiredToken = ExpiredToken.builder()
-                .expiredToken(accessToken)
+                .expiredToken(AT)
                 .build();
 
         expiredTokenRepository.save(expiredToken, StorageTimeSeconds);
 
+        refreshTokenRepository.delete(refreshToken);
     }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/service/AuthService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.budgetplanner.BudgetPlanner.auth.service;
 
+import com.budgetplanner.BudgetPlanner.auth.dto.AccessTokenResponse;
 import com.budgetplanner.BudgetPlanner.auth.dto.AuthenticationResponse;
 import com.budgetplanner.BudgetPlanner.auth.dto.UserLoginRequest;
 import com.budgetplanner.BudgetPlanner.auth.dto.UserSignupRequest;
@@ -69,6 +70,23 @@ public class AuthService {
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
+    }
+
+    public AccessTokenResponse reissue(String refreshToken) {
+
+        if (refreshTokenRepository.findById(refreshToken)) {
+            String account = jwtUtils.extractAccount(refreshToken);
+
+            User user = userRepository.findByAccount(account).orElseThrow(
+                    () -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+            String newAccessToken = jwtUtils.generateAccessToken(user);
+
+            return AccessTokenResponse.builder()
+                    .token(newAccessToken)
+                    .build();
+        }
+        throw new CustomException(ErrorCode.INVALID_TOKEN);
     }
 
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/auth/service/AuthService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/auth/service/AuthService.java
@@ -6,6 +6,8 @@ import com.budgetplanner.BudgetPlanner.auth.dto.UserSignupRequest;
 import com.budgetplanner.BudgetPlanner.auth.jwt.JwtUtils;
 import com.budgetplanner.BudgetPlanner.common.exception.CustomException;
 import com.budgetplanner.BudgetPlanner.common.exception.ErrorCode;
+import com.budgetplanner.BudgetPlanner.token.entity.RefreshToken;
+import com.budgetplanner.BudgetPlanner.token.repository.RefreshTokenRepository;
 import com.budgetplanner.BudgetPlanner.user.entity.User;
 import com.budgetplanner.BudgetPlanner.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtUtils jwtUtils;
     private final AuthenticationManager authenticationManager;
+    private final RefreshTokenRepository refreshTokenRepository;
 
 
     @Transactional
@@ -52,9 +55,19 @@ public class AuthService {
         User user = userRepository.findByAccount(request.getAccount()).orElseThrow(
                 () -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        String jwtToken = jwtUtils.generateToken(user);
+        String accessToken = jwtUtils.generateAccessToken(user);
+        String refreshToken = jwtUtils.generateRefreshToken(user);
+
+        RefreshToken RT = RefreshToken.builder()
+                .refreshToken(refreshToken)
+                .memberId(user.getId())
+                .build();
+
+        refreshTokenRepository.save(RT);
+
         return AuthenticationResponse.builder()
-                .token(jwtToken)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 

--- a/src/main/java/com/budgetplanner/BudgetPlanner/common/config/RedisConfig.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/common/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.budgetplanner.BudgetPlanner.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    private final String redisHost;
+    private final int redisPort;
+
+    public RedisConfig(@Value("${spring.redis.host}")String redisHost,
+                       @Value("${spring.redis.port}")int redisPort) {
+        this.redisHost = redisHost;
+        this.redisPort = redisPort;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/common/exception/ErrorCode.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/common/exception/ErrorCode.java
@@ -26,8 +26,7 @@ public enum ErrorCode {
     EXPENSE_USER_MISMATCH(HttpStatus.BAD_REQUEST, "E002", "기록한 유저와 찾을 유저가 일치하지 않습니다."),
 
     //statistics
-    DATA_MIS_MATCH(HttpStatus.BAD_REQUEST, "S001", "해당 데이터는 없는 케이스입니다." +
-            "")
+    DATA_MIS_MATCH(HttpStatus.BAD_REQUEST, "S001", "해당 데이터는 없는 케이스입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/budgetplanner/BudgetPlanner/token/entity/ExpiredToken.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/token/entity/ExpiredToken.java
@@ -1,0 +1,20 @@
+package com.budgetplanner.BudgetPlanner.token.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+
+@Getter
+public class ExpiredToken {
+
+    @Id
+    private String expiredToken;
+
+    private Long memberId;
+
+    @Builder
+    public ExpiredToken(String expiredToken, Long memberId) {
+        this.expiredToken = expiredToken;
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/token/entity/RefreshToken.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/token/entity/RefreshToken.java
@@ -1,0 +1,21 @@
+package com.budgetplanner.BudgetPlanner.token.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+
+@Getter
+public class RefreshToken {
+
+    @Id
+    private String refreshToken;
+
+    private Long memberId;
+
+    @Builder
+    public RefreshToken(final String refreshToken, final Long memberId) {
+        this.refreshToken = refreshToken;
+        this.memberId = memberId;
+    }
+
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/token/repository/ExpiredTokenRepository.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/token/repository/ExpiredTokenRepository.java
@@ -1,0 +1,23 @@
+package com.budgetplanner.BudgetPlanner.token.repository;
+
+import com.budgetplanner.BudgetPlanner.token.entity.ExpiredToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class ExpiredTokenRepository {
+
+    private final RedisTemplate redisTemplate;
+
+    public void save(final ExpiredToken expiredToken, long time) {
+        ValueOperations<String, Long> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(expiredToken.getExpiredToken(), expiredToken.getMemberId());
+        redisTemplate.expire(expiredToken.getExpiredToken(), time, TimeUnit.SECONDS);
+    }
+
+}

--- a/src/main/java/com/budgetplanner/BudgetPlanner/token/repository/ExpiredTokenRepository.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/token/repository/ExpiredTokenRepository.java
@@ -20,4 +20,8 @@ public class ExpiredTokenRepository {
         redisTemplate.expire(expiredToken.getExpiredToken(), time, TimeUnit.SECONDS);
     }
 
+    public boolean isBlackList(final String expiredToken) {
+        return redisTemplate.hasKey(expiredToken);
+    }
+
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/token/repository/RefreshTokenRepository.java
@@ -20,6 +20,11 @@ public class RefreshTokenRepository {
         redisTemplate.expire(refreshToken.getRefreshToken(), 60 * 60 * 24 * 7, TimeUnit.SECONDS);
     }
 
+    public boolean findById(final String refreshToken) {
+        return redisTemplate.hasKey(refreshToken);
+
+    }
+
     public void delete(final String refreshToken) {
         redisTemplate.delete(refreshToken);
     }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/token/repository/RefreshTokenRepository.java
@@ -1,0 +1,26 @@
+package com.budgetplanner.BudgetPlanner.token.repository;
+
+import com.budgetplanner.BudgetPlanner.token.entity.RefreshToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepository {
+
+    private final RedisTemplate redisTemplate;
+
+    public void save(final RefreshToken refreshToken) {
+        ValueOperations<String, Long> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(refreshToken.getRefreshToken(), refreshToken.getMemberId());
+        redisTemplate.expire(refreshToken.getRefreshToken(), 60 * 60 * 24 * 7, TimeUnit.SECONDS);
+    }
+
+    public void delete(final String refreshToken) {
+        redisTemplate.delete(refreshToken);
+    }
+}


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

- 로그인 방식 수정 -> 로그인 시 AT는 body 응답, RT는 쿠키 응답으로 변경, 로그인 시 RT는 Redis에 저장
- 토큰 재발급 -> 요청 시 Redis에 있는 RT와 일치하는 지 확인 후, 새로운 AT 발급
- 로그아웃 -> 요청 시 Redis에 저장된 RT제거, 발급기간이 남은 AT는 Redis에 블랙리스트로 저장

- 추후에 auth 관련 테스트 수정할 계획!

## 📋 변경 사항

- [x] 새로운 기능 추가

## 📸 스크린샷

(선택 사항: 변경된 내용을 시각적으로 보여주기 위해 스크린샷을 첨부하세요.)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.

## 📎 관련 이슈

#48 

## 🙌 리뷰 및 피드백

(리뷰어들께 질문하거나 특정 리뷰를 요청하는 내용을 작성하세요.)