### PR TITLE
feat: data caching

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/budgetplanner/BudgetPlanner/BudgetPlannerApplication.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/BudgetPlannerApplication.java
@@ -2,8 +2,10 @@ package com.budgetplanner.BudgetPlanner;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class BudgetPlannerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/budgetplanner/BudgetPlanner/BudgetPlannerApplication.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/BudgetPlannerApplication.java
@@ -3,9 +3,11 @@ package com.budgetplanner.BudgetPlanner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableCaching
+@EnableScheduling
 public class BudgetPlannerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/dto/CategoriesResponse.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/dto/CategoriesResponse.java
@@ -1,8 +1,10 @@
 package com.budgetplanner.BudgetPlanner.budget.dto;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class CategoriesResponse {
 
     private String categoryCode;

--- a/src/main/java/com/budgetplanner/BudgetPlanner/budget/service/BudgetService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/budget/service/BudgetService.java
@@ -12,6 +12,7 @@ import com.budgetplanner.BudgetPlanner.common.exception.ErrorCode;
 import com.budgetplanner.BudgetPlanner.user.entity.User;
 import com.budgetplanner.BudgetPlanner.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +31,7 @@ public class BudgetService {
     private final BudgetRepository budgetRepository;
     private final UserRepository userRepository;
 
+    @Cacheable(value = "categories", key = "'allCategories'")
     public List<CategoriesResponse> getCategories() {
 
         return Arrays.stream(Category.values())
@@ -67,6 +69,7 @@ public class BudgetService {
     }
 
 
+    @Cacheable(value = "budget", key = "'recommend'")
     public List<BudgetRecommendResponse> recommend(BudgetRecommendRequest request) {
         List<Object[]> data = budgetRepository.findCategoryAndBudget();
         long[] budgets = data.stream().mapToLong(entry -> ((Number) entry[1]).longValue()).toArray();

--- a/src/main/java/com/budgetplanner/BudgetPlanner/common/config/RedisConfig.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/common/config/RedisConfig.java
@@ -1,13 +1,23 @@
 package com.budgetplanner.BudgetPlanner.common.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
 
 @Configuration
 public class RedisConfig {
@@ -33,5 +43,28 @@ public class RedisConfig {
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
         return redisTemplate;
+    }
+
+    @Bean
+    public RedisCacheManager redisCacheManager() {
+
+        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
+                .allowIfBaseType(Object.class)
+                .build();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL);
+        GenericJackson2JsonRedisSerializer redisSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.
+                        SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(redisSerializer))
+                .entryTtl(Duration.ofDays(1L));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory())
+                .cacheDefaults(redisCacheConfiguration).build();
     }
 }

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/ResultExpensesResponse.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/dto/ResultExpensesResponse.java
@@ -3,11 +3,13 @@ package com.budgetplanner.BudgetPlanner.expense.dto;
 import com.budgetplanner.BudgetPlanner.budget.entity.Category;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.Map;
 
 @Getter
+@NoArgsConstructor
 public class ResultExpensesResponse {
 
     private Long totalExpenses;

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expense/service/ExpenseService.java
@@ -9,6 +9,8 @@ import com.budgetplanner.BudgetPlanner.expense.repository.ExpenseRepository;
 import com.budgetplanner.BudgetPlanner.user.entity.User;
 import com.budgetplanner.BudgetPlanner.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,6 +65,7 @@ public class ExpenseService {
         return response;
     }
 
+    @Cacheable(value = "expense", key = "'list:' + #authentication.name")
     public ResultExpensesResponse getExpenses(Authentication authentication, ParamsRequest request) {
         User user = userRepository.findByAccount(authentication.getName())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -92,6 +95,7 @@ public class ExpenseService {
                 .build();
     }
 
+    @CacheEvict(value = "expense", key = "'list:' + #authentication.name")
     @Transactional
     public void update(Long id, Authentication authentication, UpdateExpenseRequest request) {
 
@@ -107,6 +111,7 @@ public class ExpenseService {
                 request.getCategory(), request.getMemo());
     }
 
+    @CacheEvict(value = "expense", key = "'list:' + #authentication.name")
     @Transactional
     public void delete(Long id, Authentication authentication) {
         userRepository.findByAccount(authentication.getName())
@@ -115,6 +120,7 @@ public class ExpenseService {
         expenseRepository.deleteById(id);
     }
 
+    @CacheEvict(value = "expense", key = "'list:' + #authentication.name")
     @Transactional
     public void exclude(Long id, Authentication authentication) {
         User user = userRepository.findByAccount(authentication.getName())

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expenseadvisor/service/ExpenseAdvisorService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expenseadvisor/service/ExpenseAdvisorService.java
@@ -104,11 +104,11 @@ public class ExpenseAdvisorService {
     }
 
     @CacheEvict(value = "expense", key = "'recommend:' + #authentication.name")
-    @Scheduled(cron = "0 0 10 * * ?")
+    @Scheduled(cron = "0 59 09 * * ?")
     public void recommendDataReset() {}
 
     @CacheEvict(value = "expense", key = "'guide:' + #authentication.name")
-    @Scheduled(cron = "0 0 22 * * ?")
+    @Scheduled(cron = "0 59 21 * * ?")
     public void guideDataReset() {}
 
     /*

--- a/src/main/java/com/budgetplanner/BudgetPlanner/expenseadvisor/service/ExpenseAdvisorService.java
+++ b/src/main/java/com/budgetplanner/BudgetPlanner/expenseadvisor/service/ExpenseAdvisorService.java
@@ -12,6 +12,9 @@ import com.budgetplanner.BudgetPlanner.expenseadvisor.dto.BudgetRecommendationRe
 import com.budgetplanner.BudgetPlanner.user.entity.User;
 import com.budgetplanner.BudgetPlanner.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
@@ -38,6 +41,7 @@ public class ExpenseAdvisorService {
     /*
      * 오늘 지출 추천
      * */
+    @Cacheable(value = "expense", key = "'recommend:' + #authentication.name")
     public BudgetRecommendationResponse getRecommendation(Authentication authentication) {
 
         User user = getUser(authentication);
@@ -67,6 +71,7 @@ public class ExpenseAdvisorService {
     /*
     * 오늘 지출 안내
     * */
+    @Cacheable(value = "expense", key = "'guide:' + #authentication.name")
     public BudgetGuideResponse getGuide(Authentication authentication) {
 
         User user = getUser(authentication);
@@ -97,6 +102,14 @@ public class ExpenseAdvisorService {
                 .risk(riskByCategory)
                 .build();
     }
+
+    @CacheEvict(value = "expense", key = "'recommend:' + #authentication.name")
+    @Scheduled(cron = "0 0 10 * * ?")
+    public void recommendDataReset() {}
+
+    @CacheEvict(value = "expense", key = "'guide:' + #authentication.name")
+    @Scheduled(cron = "0 0 22 * * ?")
+    public void guideDataReset() {}
 
     /*
      * 오늘 지출 추천 - 웹훅


### PR DESCRIPTION
## 🚀 풀 리퀘스트 요약

`Redis를 이용한 데이터 캐싱`

- 카테고리 목록
- 예산 설계(추천)
- 지출 목록 조회
- 지출 컨설팅(오늘 지출 추천 및 안내)

`변동의 성격이 강하지 않은` 위의 데이터를 선별하여 데이터 캐싱을 진행했습니다.

- 지출 목록의 경우 수정 및 삭제 시 캐시 데이터 삭제를 진행합니다.
- 지출 컨설팅 같은 경우는 스케줄링 기능을 사용해 알림 발송 직전에 캐시 데이터를 삭제합니다.


## 📋 변경 사항

- [x] 새로운 기능 추가
- [x] 버그 수정

## 📸 스크린샷

(선택 사항: 변경된 내용을 시각적으로 보여주기 위해 스크린샷을 첨부하세요.)

## 📌 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.

## 📎 관련 이슈

#52 

## 🙌 리뷰 및 피드백

(리뷰어들께 질문하거나 특정 리뷰를 요청하는 내용을 작성하세요.)